### PR TITLE
Adding more growth chambers

### DIFF
--- a/src/main/java/me/profelements/dynatech/DynaTechItems.java
+++ b/src/main/java/me/profelements/dynatech/DynaTechItems.java
@@ -242,7 +242,7 @@ public class DynaTechItems {
             "&bOcean Growth Chamber MK2",
             "",
             "&fAutomatically grows &9water &fplants.",
-            "Can revive dead coral!"
+            "Can revive dead coral!",
             "",
             "&c3x production.",
             LoreBuilder.machine(MachineTier.MEDIUM, MachineType.MACHINE),

--- a/src/main/java/me/profelements/dynatech/DynaTechItems.java
+++ b/src/main/java/me/profelements/dynatech/DynaTechItems.java
@@ -180,7 +180,7 @@ public class DynaTechItems {
             );
 
     public static final SlimefunItemStack GROWTH_CHAMBER_END = new SlimefunItemStack("GROWTH_CHAMBER_END",
-            Material.GREEN_STAINED_GLASS,
+            Material.MAGENTA_STAINED_GLASS,
             "&dEnd Growth Chamber",
             "",
             "&fAutomatically grows &dchorus flowers.",
@@ -191,7 +191,7 @@ public class DynaTechItems {
             );
 
     public static final SlimefunItemStack GROWTH_CHAMBER_END_MK2 = new SlimefunItemStack("GROWTH_CHAMBER_END_MK2",
-            Material.LIME_STAINED_GLASS,
+            Material.PURPLE_STAINED_GLASS,
             "&dEnd Growth Chamber MK2",
             "",
             "&fAutomatically grows &dchorus flowers.",
@@ -203,7 +203,7 @@ public class DynaTechItems {
             );
 
     public static final SlimefunItemStack GROWTH_CHAMBER_NETHER = new SlimefunItemStack("GROWTH_CHAMBER_NETHER",
-            Material.GREEN_STAINED_GLASS,
+            Material.RED_STAINED_GLASS,
             "&cNether Growth Chamber",
             "",
             "&fAutomatically grows &cnether &fplants.",
@@ -214,7 +214,7 @@ public class DynaTechItems {
             );
 
     public static final SlimefunItemStack GROWTH_CHAMBER_NETHER_MK2 = new SlimefunItemStack("GROWTH_CHAMBER_NETHER_MK2",
-            Material.LIME_STAINED_GLASS,
+            Material.RED_STAINED_GLASS,
             "&cNether Growth Chamber MK2",
             "",
             "&fAutomatically grows &cnether &fplants.",
@@ -226,7 +226,7 @@ public class DynaTechItems {
             );
 
     public static final SlimefunItemStack GROWTH_CHAMBER_OCEAN = new SlimefunItemStack("GROWTH_CHAMBER_OCEAN",
-            Material.GREEN_STAINED_GLASS,
+            Material.CYAN_STAINED_GLASS,
             "&bOcean Growth Chamber",
             "",
             "&fAutomatically grows &9water &fplants.",
@@ -238,7 +238,7 @@ public class DynaTechItems {
             );
 
     public static final SlimefunItemStack GROWTH_CHAMBER_OCEAN_MK2 = new SlimefunItemStack("GROWTH_CHAMBER_OCEAN_MK2",
-            Material.LIME_STAINED_GLASS,
+            Material.LIGHT_BLUE_STAINED_GLASS,
             "&bOcean Growth Chamber MK2",
             "",
             "&fAutomatically grows &9water &fplants.",

--- a/src/main/java/me/profelements/dynatech/DynaTechItems.java
+++ b/src/main/java/me/profelements/dynatech/DynaTechItems.java
@@ -156,7 +156,7 @@ public class DynaTechItems {
             Material.GREEN_STAINED_GLASS,
             "&6Growth Chamber",
             "",
-            "&fAutomatically grows some plants.",
+            "&fAutomatically grows &eplants&f.",
             "",
             "&f&oIts like a small greenhouse!",
             "",
@@ -169,13 +169,85 @@ public class DynaTechItems {
             Material.LIME_STAINED_GLASS,
             "&6Growth Chamber MK2",
             "",
-            "&fAutomatically grows most plants.",
-            "&c3x production",
+            "&fAutomatically grows &eplants&f.",
+            "",
             "&f&oIts like a small greenhouse!",
             "",
+            "&c3x production.",
             LoreBuilder.machine(MachineTier.MEDIUM, MachineType.MACHINE),
-            LoreBuilder.speed(4),
-            LoreBuilder.powerPerSecond(80)
+            LoreBuilder.speed(3),
+            LoreBuilder.powerPerSecond(128)
+            );
+
+    public static final SlimefunItemStack GROWTH_CHAMBER_END = new SlimefunItemStack("GROWTH_CHAMBER_END",
+            Material.GREEN_STAINED_GLASS,
+            "&dEnd Growth Chamber",
+            "",
+            "&fAutomatically grows &dchorus flowers.",
+            "",
+            LoreBuilder.machine(MachineTier.MEDIUM, MachineType.MACHINE),
+            LoreBuilder.speed(1),
+            LoreBuilder.powerPerSecond(32)
+            );
+
+    public static final SlimefunItemStack GROWTH_CHAMBER_END_MK2 = new SlimefunItemStack("GROWTH_CHAMBER_END_MK2",
+            Material.LIME_STAINED_GLASS,
+            "&dEnd Growth Chamber MK2",
+            "",
+            "&fAutomatically grows &dchorus flowers.",
+            "",
+            "&c3x production.",
+            LoreBuilder.machine(MachineTier.MEDIUM, MachineType.MACHINE),
+            LoreBuilder.speed(3),
+            LoreBuilder.powerPerSecond(128)
+            );
+
+    public static final SlimefunItemStack GROWTH_CHAMBER_NETHER = new SlimefunItemStack("GROWTH_CHAMBER_NETHER",
+            Material.GREEN_STAINED_GLASS,
+            "&cNether Growth Chamber",
+            "",
+            "&fAutomatically grows &cnether &fplants.",
+            "",
+            LoreBuilder.machine(MachineTier.MEDIUM, MachineType.MACHINE),
+            LoreBuilder.speed(1),
+            LoreBuilder.powerPerSecond(32)
+            );
+
+    public static final SlimefunItemStack GROWTH_CHAMBER_NETHER_MK2 = new SlimefunItemStack("GROWTH_CHAMBER_NETHER_MK2",
+            Material.LIME_STAINED_GLASS,
+            "&cNether Growth Chamber MK2",
+            "",
+            "&fAutomatically grows &cnether &fplants.",
+            "",
+            "&c3x production.",
+            LoreBuilder.machine(MachineTier.MEDIUM, MachineType.MACHINE),
+            LoreBuilder.speed(3),
+            LoreBuilder.powerPerSecond(128)
+            );
+
+    public static final SlimefunItemStack GROWTH_CHAMBER_OCEAN = new SlimefunItemStack("GROWTH_CHAMBER_OCEAN",
+            Material.GREEN_STAINED_GLASS,
+            "&bOcean Growth Chamber",
+            "",
+            "&fAutomatically grows &9water &fplants.",
+            "Can revive dead coral!",
+            "",
+            LoreBuilder.machine(MachineTier.MEDIUM, MachineType.MACHINE),
+            LoreBuilder.speed(1),
+            LoreBuilder.powerPerSecond(32)
+            );
+
+    public static final SlimefunItemStack GROWTH_CHAMBER_OCEAN_MK2 = new SlimefunItemStack("GROWTH_CHAMBER_OCEAN_MK2",
+            Material.LIME_STAINED_GLASS,
+            "&bOcean Growth Chamber MK2",
+            "",
+            "&fAutomatically grows &9water &fplants.",
+            "Can revive dead coral!"
+            "",
+            "&c3x production.",
+            LoreBuilder.machine(MachineTier.MEDIUM, MachineType.MACHINE),
+            LoreBuilder.speed(3),
+            LoreBuilder.powerPerSecond(128)
             );
 
     public static final SlimefunItemStack ANTIGRAVITY_BUBBLE = new SlimefunItemStack("ANTIGRAVITY_BUBBLE",

--- a/src/main/java/me/profelements/dynatech/items/electric/GrowthChamber.java
+++ b/src/main/java/me/profelements/dynatech/items/electric/GrowthChamber.java
@@ -27,29 +27,53 @@ public class GrowthChamber extends AMachine {
     @Override
     protected void registerDefaultRecipes() {
 
-        registerRecipe(20, new ItemStack(Material.WHEAT_SEEDS), new ItemStack(Material.WHEAT, 4));
-        registerRecipe(20, new ItemStack(Material.BEETROOT_SEEDS), new ItemStack(Material.BEETROOT, 4));
-        registerRecipe(20, new ItemStack(Material.PUMPKIN_SEEDS), new ItemStack(Material.PUMPKIN, 2));
-        registerRecipe(20, new ItemStack(Material.MELON_SEEDS), new ItemStack(Material.MELON, 2));
-        registerRecipe(20, new ItemStack(Material.COCOA_BEANS), new ItemStack(Material.COCOA_BEANS, 4));
+        registerRecipe(9, new ItemStack(Material.COCOA_BEANS), new ItemStack(Material.COCOA_BEANS, 3));
+        registerRecipe(15, new ItemStack[] {new ItemStack(Material.MELON_SEEDS)}, new ItemStack[] {new ItemStack(Material.MELON , 1), new ItemStack(Material.MELON_SEEDS, 1)});
+        registerRecipe(15, new ItemStack[] {new ItemStack(Material.PUMPKIN_SEEDS)}, new ItemStack[] {new ItemStack(Material.PUMPKIN , 1), new ItemStack(Material.PUMPKIN_SEEDS, 1)});
+        registerRecipe(15, new ItemStack[] {new ItemStack(Material.BEETROOT_SEEDS)}, new ItemStack[] {new ItemStack(Material.BEETROOT , 3), new ItemStack(Material.BEETROOT_SEEDS, 2)});
+        registerRecipe(12, new ItemStack[] {new ItemStack(Material.WHEAT_SEEDS)}, new ItemStack[] {new ItemStack(Material.WHEAT , 3), new ItemStack(Material.WHEAT_SEEDS, 2)});
+        registerRecipe(9, new ItemStack(Material.APPLE), new ItemStack(Material.APPLE, 3));
+        registerRecipe(9, new ItemStack(Material.BROWN_MUSHROOM), new ItemStack(Material.BROWN_MUSHROOM, 3));
+        registerRecipe(9, new ItemStack(Material.RED_MUSHROOM), new ItemStack(Material.RED_MUSHROOM, 3));
+        registerRecipe(9, new ItemStack[] {new ItemStack(Material.DEAD_BUSH)}, new ItemStack[] {new ItemStack(Material.DEAD_BUSH , 3), new ItemStack(Material.STICK, 2)});
+        registerRecipe(9, new ItemStack(Material.GRASS), new ItemStack(Material.GRASS, 3));
+        registerRecipe(12, new ItemStack(Material.TALL_GRASS), new ItemStack(Material.TALL_GRASS, 3));
+        registerRecipe(9, new ItemStack(Material.FERN), new ItemStack(Material.FERN, 3));
+        registerRecipe(12, new ItemStack(Material.LARGE_FERN), new ItemStack(Material.LARGE_FERN, 3));
+        registerRecipe(9, new ItemStack(Material.VINE), new ItemStack(Material.VINE, 3));
 
-        registerRecipe(25, new ItemStack(Material.NETHER_WART), new ItemStack(Material.NETHER_WART, 4));
+    // Flowers
+        registerRecipe(9, new ItemStack(Material.DANDELION), new ItemStack(Material.DANDELION, 3));
+        registerRecipe(9, new ItemStack(Material.POPPY), new ItemStack(Material.POPPY, 3));
+        registerRecipe(9, new ItemStack(Material.BLUE_ORCHID), new ItemStack(Material.BLUE_ORCHID, 3));
+        registerRecipe(9, new ItemStack(Material.ALLIUM), new ItemStack(Material.ALLIUM, 3));
+        registerRecipe(9, new ItemStack(Material.AZURE_BLUET), new ItemStack(Material.AZURE_BLUET, 3));
+        registerRecipe(9, new ItemStack(Material.RED_TULIP), new ItemStack(Material.RED_TULIP, 3));
+        registerRecipe(9, new ItemStack(Material.ORANGE_TULIP), new ItemStack(Material.ORANGE_TULIP, 3));
+        registerRecipe(9, new ItemStack(Material.WHITE_TULIP), new ItemStack(Material.WHITE_TULIP, 3));
+        registerRecipe(9, new ItemStack(Material.PINK_TULIP), new ItemStack(Material.PINK_TULIP, 3));
+        registerRecipe(9, new ItemStack(Material.OXEYE_DAISY), new ItemStack(Material.OXEYE_DAISY, 3));
+        registerRecipe(9, new ItemStack(Material.CORNFLOWER), new ItemStack(Material.CORNFLOWER, 3));
+        registerRecipe(9, new ItemStack(Material.LILY_OF_THE_VALLEY), new ItemStack(Material.LILY_OF_THE_VALLEY, 3));
+        registerRecipe(12, new ItemStack(Material.WITHER_ROSE), new ItemStack(Material.WITHER_ROSE, 2));
+        registerRecipe(12, new ItemStack(Material.SUNFLOWER), new ItemStack(Material.SUNFLOWER, 2));
+        registerRecipe(12, new ItemStack(Material.LILAC), new ItemStack(Material.LILAC, 2));
+        registerRecipe(12, new ItemStack(Material.ROSE_BUSH), new ItemStack(Material.ROSE_BUSH, 2));
+        registerRecipe(12, new ItemStack(Material.PEONY), new ItemStack(Material.PEONY, 2));
 
-        registerRecipe(30, new ItemStack(Material.CARROT), new ItemStack(Material.CARROT, 3));
-        registerRecipe(30, new ItemStack(Material.POTATO), new ItemStack(Material.POTATO, 3));
-        registerRecipe(30, new ItemStack(Material.SWEET_BERRIES), new ItemStack(Material.SWEET_BERRIES, 3));
+        registerRecipe(12, new ItemStack(Material.CARROT), new ItemStack(Material.CARROT, 3));
+        registerRecipe(12, new ItemStack(Material.POTATO), new ItemStack(Material.POTATO, 3));
+        registerRecipe(12, new ItemStack(Material.SWEET_BERRIES), new ItemStack(Material.SWEET_BERRIES, 3));
+        registerRecipe(12, new ItemStack(Material.SUGAR_CANE), new ItemStack(Material.SUGAR_CANE, 3));
+        registerRecipe(12, new ItemStack(Material.BAMBOO), new ItemStack(Material.BAMBOO, 3));
+        registerRecipe(12, new ItemStack(Material.CACTUS), new ItemStack(Material.CACTUS, 3));
 
-        registerRecipe(35, new ItemStack(Material.KELP), new ItemStack(Material.KELP, 2));
-        registerRecipe(35, new ItemStack(Material.SUGAR_CANE), new ItemStack(Material.SUGAR_CANE, 2));
-        registerRecipe(35, new ItemStack(Material.BAMBOO), new ItemStack(Material.BAMBOO, 2));
-        registerRecipe(35, new ItemStack(Material.CACTUS), new ItemStack(Material.CACTUS, 2));
-
-        registerRecipe(40, new ItemStack[] {new ItemStack(Material.OAK_SAPLING)}, new ItemStack[] {new ItemStack(Material.OAK_SAPLING , 3), new ItemStack(Material.OAK_LOG, 6)});
-        registerRecipe(40, new ItemStack[] {new ItemStack(Material.BIRCH_SAPLING)}, new ItemStack[] {new ItemStack(Material.BIRCH_SAPLING , 3), new ItemStack(Material.BIRCH_LOG, 6)});
-        registerRecipe(40, new ItemStack[] {new ItemStack(Material.SPRUCE_SAPLING)}, new ItemStack[] {new ItemStack(Material.SPRUCE_SAPLING , 3), new ItemStack(Material.SPRUCE_LOG, 6)});
-        registerRecipe(40, new ItemStack[] {new ItemStack(Material.DARK_OAK_SAPLING)}, new ItemStack[] {new ItemStack(Material.DARK_OAK_SAPLING , 3), new ItemStack(Material.DARK_OAK_LOG, 6)});
-        registerRecipe(40, new ItemStack[] {new ItemStack(Material.JUNGLE_SAPLING)}, new ItemStack[] {new ItemStack(Material.JUNGLE_SAPLING, 3), new ItemStack(Material.JUNGLE_LOG, 6)});
-        registerRecipe(40, new ItemStack[] {new ItemStack(Material.ACACIA_SAPLING)}, new ItemStack[] {new ItemStack(Material.ACACIA_SAPLING, 3), new ItemStack(Material.ACACIA_LOG, 6)});
+        registerRecipe(30, new ItemStack[] {new ItemStack(Material.OAK_SAPLING)}, new ItemStack[] {new ItemStack(Material.OAK_SAPLING , 3), new ItemStack(Material.OAK_LOG, 6)});
+        registerRecipe(30, new ItemStack[] {new ItemStack(Material.BIRCH_SAPLING)}, new ItemStack[] {new ItemStack(Material.BIRCH_SAPLING , 3), new ItemStack(Material.BIRCH_LOG, 6)});
+        registerRecipe(30, new ItemStack[] {new ItemStack(Material.SPRUCE_SAPLING)}, new ItemStack[] {new ItemStack(Material.SPRUCE_SAPLING , 3), new ItemStack(Material.SPRUCE_LOG, 6)});
+        registerRecipe(30, new ItemStack[] {new ItemStack(Material.DARK_OAK_SAPLING)}, new ItemStack[] {new ItemStack(Material.DARK_OAK_SAPLING , 3), new ItemStack(Material.DARK_OAK_LOG, 6)});
+        registerRecipe(30, new ItemStack[] {new ItemStack(Material.JUNGLE_SAPLING)}, new ItemStack[] {new ItemStack(Material.JUNGLE_SAPLING, 3), new ItemStack(Material.JUNGLE_LOG, 6)});
+        registerRecipe(30, new ItemStack[] {new ItemStack(Material.ACACIA_SAPLING)}, new ItemStack[] {new ItemStack(Material.ACACIA_SAPLING, 3), new ItemStack(Material.ACACIA_LOG, 6)});
 
     }
     
@@ -63,7 +87,7 @@ public class GrowthChamber extends AMachine {
                     if (sfItem.getId().contains("_BUSH") || sfItem.getId().contains("_PLANT") || sfItem.getId().contains("_SAPLING")) {
                         if (sfItem.getId().contains("_BUSH")) {
                             ItemStack fruit = SlimefunItem.getByID(sfItem.getId().replace("_BUSH", "")).getItem();
-                            MachineRecipe recipe = new MachineRecipe(20, new ItemStack[] {sfItem.getItem()}, new ItemStack[] {sfItem.getItem(), fruit});
+                            MachineRecipe recipe = new MachineRecipe(21, new ItemStack[] {sfItem.getItem()}, new ItemStack[] {sfItem.getItem(), fruit});
                             
                             inv.consumeItem(inputSlot);
 
@@ -71,7 +95,7 @@ public class GrowthChamber extends AMachine {
                         } else 
                         if (sfItem.getId().contains("_PLANT")) {
                             ItemStack fruit = SlimefunItem.getByID(sfItem.getId().replace("_PLANT", "")) != null ? SlimefunItem.getByID(sfItem.getId().replace("_PLANT", "")).getItem() : SlimefunItem.getByID(sfItem.getId().replace("_PLANT", "_ESSENCE")).getItem();
-                            MachineRecipe recipe = new MachineRecipe(10, new ItemStack[] {sfItem.getItem()}, new ItemStack[] {sfItem.getItem(), fruit});
+                            MachineRecipe recipe = new MachineRecipe(12, new ItemStack[] {sfItem.getItem()}, new ItemStack[] {sfItem.getItem(), fruit});
                             
                             inv.consumeItem(inputSlot);
 
@@ -80,7 +104,7 @@ public class GrowthChamber extends AMachine {
                         if (sfItem.getId().contains("_SAPLING")) {
                             ItemStack fruit = SlimefunItem.getByID(sfItem.getId().replace("_SAPLING", "")).getItem();
                             fruit.setAmount(3);
-                            MachineRecipe recipe = new MachineRecipe(60, new ItemStack[] {sfItem.getItem()}, new ItemStack[] {sfItem.getItem(), fruit});
+                            MachineRecipe recipe = new MachineRecipe(30, new ItemStack[] {sfItem.getItem()}, new ItemStack[] {sfItem.getItem(), fruit});
                             
                             inv.consumeItem(inputSlot);
                             
@@ -97,7 +121,7 @@ public class GrowthChamber extends AMachine {
 
     @Override
     public ItemStack getProgressBar() {
-        return new ItemStack(Material.WOODEN_HOE);
+        return new ItemStack(Material.IRON_HOE);
     }
 
     @Override

--- a/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberEnd.java
+++ b/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberEnd.java
@@ -1,0 +1,39 @@
+package me.profelements.dynatech.items.electric;
+
+import me.mrCookieSlime.Slimefun.Lists.RecipeType;
+import me.mrCookieSlime.Slimefun.Objects.Category;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineRecipe;
+import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
+import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
+import me.profelements.dynatech.DynaTech;
+import me.profelements.dynatech.items.electric.abstracts.AMachine;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+public class GrowthChamberEnd extends AMachine {
+
+    public GrowthChamberEnd(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(category, item, recipeType, recipe);
+
+    }
+
+    @Override
+    protected void registerDefaultRecipes() {
+
+        registerRecipe(20, new ItemStack[] {new ItemStack(Material.CHORUS_FLOWER)}, new ItemStack[] {new ItemStack(Material.CHORUS_FLOWER , 2), new ItemStack(Material.CHORUS_FRUIT, 8)});
+
+    } 
+
+    @Override
+    public ItemStack getProgressBar() {
+        return new ItemStack(Material.CHORUS_FLOWER);
+    }
+
+    @Override
+    public String getMachineIdentifier() {
+        return "GROWTH_CHAMBER_END";
+    }
+
+}

--- a/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberEnd.java
+++ b/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberEnd.java
@@ -22,7 +22,7 @@ public class GrowthChamberEnd extends AMachine {
     @Override
     protected void registerDefaultRecipes() {
 
-        registerRecipe(20, new ItemStack[] {new ItemStack(Material.CHORUS_FLOWER)}, new ItemStack[] {new ItemStack(Material.CHORUS_FLOWER , 2), new ItemStack(Material.CHORUS_FRUIT, 8)});
+        registerRecipe(9, new ItemStack[] {new ItemStack(Material.CHORUS_FLOWER)}, new ItemStack[] {new ItemStack(Material.CHORUS_FLOWER , 2), new ItemStack(Material.CHORUS_FRUIT, 8)});
 
     } 
 

--- a/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberEndMK2.java
+++ b/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberEndMK2.java
@@ -22,7 +22,7 @@ public class GrowthChamberEndMK2 extends AMachine {
     @Override
     protected void registerDefaultRecipes() {
 
-        registerRecipe(20, new ItemStack[] {new ItemStack(Material.CHORUS_FLOWER)}, new ItemStack[] {new ItemStack(Material.CHORUS_FLOWER , 6), new ItemStack(Material.CHORUS_FRUIT, 24)});
+        registerRecipe(9, new ItemStack[] {new ItemStack(Material.CHORUS_FLOWER)}, new ItemStack[] {new ItemStack(Material.CHORUS_FLOWER , 6), new ItemStack(Material.CHORUS_FRUIT, 24)});
 
     } 
 

--- a/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberEndMK2.java
+++ b/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberEndMK2.java
@@ -1,0 +1,39 @@
+package me.profelements.dynatech.items.electric;
+
+import me.mrCookieSlime.Slimefun.Lists.RecipeType;
+import me.mrCookieSlime.Slimefun.Objects.Category;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineRecipe;
+import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
+import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
+import me.profelements.dynatech.DynaTech;
+import me.profelements.dynatech.items.electric.abstracts.AMachine;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+public class GrowthChamberEndMK2 extends AMachine {
+
+    public GrowthChamberEndMK2(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(category, item, recipeType, recipe);
+
+    }
+
+    @Override
+    protected void registerDefaultRecipes() {
+
+        registerRecipe(20, new ItemStack[] {new ItemStack(Material.CHORUS_FLOWER)}, new ItemStack[] {new ItemStack(Material.CHORUS_FLOWER , 6), new ItemStack(Material.CHORUS_FRUIT, 24)});
+
+    } 
+
+    @Override
+    public ItemStack getProgressBar() {
+        return new ItemStack(Material.CHORUS_FLOWER);
+    }
+
+    @Override
+    public String getMachineIdentifier() {
+        return "GROWTH_CHAMBER_END_MK2";
+    }
+
+}

--- a/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberMK2.java
+++ b/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberMK2.java
@@ -34,45 +34,53 @@ public class GrowthChamberMK2 extends AMachine {
     @Override
     protected void registerDefaultRecipes() {
 
-        registerRecipe(20, new ItemStack(Material.COCOA_BEANS), new ItemStack(Material.COCOA_BEANS, 8));
-        registerRecipe(20, new ItemStack[] {new ItemStack(Material.MELON_SEEDS)}, new ItemStack[] {new ItemStack(Material.MELON , 6), new ItemStack(Material.MELON_SEEDS, 3)});
-        registerRecipe(20, new ItemStack[] {new ItemStack(Material.PUMPKIN_SEEDS)}, new ItemStack[] {new ItemStack(Material.PUMPKIN , 6), new ItemStack(Material.PUMPKIN_SEEDS, 3)});
-        registerRecipe(20, new ItemStack[] {new ItemStack(Material.BEETROOT_SEEDS)}, new ItemStack[] {new ItemStack(Material.BEETROOT , 12), new ItemStack(Material.BEETROOT_SEEDS, 3)});
-        registerRecipe(20, new ItemStack[] {new ItemStack(Material.WHEAT_SEEDS)}, new ItemStack[] {new ItemStack(Material.WHEAT , 12), new ItemStack(Material.WHEAT_SEEDS, 3)});
-        registerRecipe(20, new ItemStack(Material.APPLE), new ItemStack(Material.APPLE, 3));
-        registerRecipe(20, new ItemStack(Material.BROWN_MUSHROOM), new ItemStack(Material.BROWN_MUSHROOM, 6));
-        registerRecipe(20, new ItemStack(Material.RED_MUSHROOM), new ItemStack(Material.RED_MUSHROOM, 6));
-        registerRecipe(20, new ItemStack(Material.CRIMSON_ROOTS), new ItemStack(Material.CRIMSON_ROOTS, 6));
-        registerRecipe(20, new ItemStack(Material.WARPED_ROOTS), new ItemStack(Material.WARPED_ROOTS, 6));
-        registerRecipe(20, new ItemStack(Material.NETHER_SPROUTS), new ItemStack(Material.NETHER_SPROUTS, 6));
-        registerRecipe(20, new ItemStack(Material.LILY_PAD), new ItemStack(Material.LILY_PAD, 6));
-        registerRecipe(20, new ItemStack(Material.VINE), new ItemStack(Material.VINE, 6));
-        registerRecipe(20, new ItemStack(Material.SEA_PICKLE), new ItemStack(Material.SEA_PICKLE, 6));
-        registerRecipe(20, new ItemStack(Material.SEAGRASS), new ItemStack(Material.SEAGRASS, 6));
+        registerRecipe(9, new ItemStack(Material.COCOA_BEANS), new ItemStack(Material.COCOA_BEANS, 9));
+        registerRecipe(15, new ItemStack[] {new ItemStack(Material.MELON_SEEDS)}, new ItemStack[] {new ItemStack(Material.MELON , 3), new ItemStack(Material.MELON_SEEDS, 3)});
+        registerRecipe(15, new ItemStack[] {new ItemStack(Material.PUMPKIN_SEEDS)}, new ItemStack[] {new ItemStack(Material.PUMPKIN , 3), new ItemStack(Material.PUMPKIN_SEEDS, 3)});
+        registerRecipe(15, new ItemStack[] {new ItemStack(Material.BEETROOT_SEEDS)}, new ItemStack[] {new ItemStack(Material.BEETROOT , 9), new ItemStack(Material.BEETROOT_SEEDS, 6)});
+        registerRecipe(12, new ItemStack[] {new ItemStack(Material.WHEAT_SEEDS)}, new ItemStack[] {new ItemStack(Material.WHEAT , 9), new ItemStack(Material.WHEAT_SEEDS, 6)});
+        registerRecipe(9, new ItemStack(Material.APPLE), new ItemStack(Material.APPLE, 9));
+        registerRecipe(9, new ItemStack(Material.BROWN_MUSHROOM), new ItemStack(Material.BROWN_MUSHROOM, 9));
+        registerRecipe(9, new ItemStack(Material.RED_MUSHROOM), new ItemStack(Material.RED_MUSHROOM, 9));
+        registerRecipe(9, new ItemStack[] {new ItemStack(Material.DEAD_BUSH)}, new ItemStack[] {new ItemStack(Material.DEAD_BUSH , 9), new ItemStack(Material.STICK, 6)});
+        registerRecipe(9, new ItemStack(Material.GRASS), new ItemStack(Material.GRASS, 9));
+        registerRecipe(12, new ItemStack(Material.TALL_GRASS), new ItemStack(Material.TALL_GRASS, 9));
+        registerRecipe(9, new ItemStack(Material.FERN), new ItemStack(Material.FERN, 9));
+        registerRecipe(12, new ItemStack(Material.LARGE_FERN), new ItemStack(Material.LARGE_FERN, 9));
+        registerRecipe(9, new ItemStack(Material.VINE), new ItemStack(Material.VINE, 9));
 
-        registerRecipe(25, new ItemStack(Material.NETHER_WART), new ItemStack(Material.NETHER_WART, 12));
-        registerRecipe(25, new ItemStack(Material.WEEPING_VINES), new ItemStack(Material.WEEPING_VINES, 6));
-        registerRecipe(25, new ItemStack(Material.TWISTING_VINES), new ItemStack(Material.TWISTING_VINES, 6));
+    // Flowers
+        registerRecipe(9, new ItemStack(Material.DANDELION), new ItemStack(Material.DANDELION, 9));
+        registerRecipe(9, new ItemStack(Material.POPPY), new ItemStack(Material.POPPY, 3));
+        registerRecipe(9, new ItemStack(Material.BLUE_ORCHID), new ItemStack(Material.BLUE_ORCHID, 9));
+        registerRecipe(9, new ItemStack(Material.ALLIUM), new ItemStack(Material.ALLIUM, 9));
+        registerRecipe(9, new ItemStack(Material.AZURE_BLUET), new ItemStack(Material.AZURE_BLUET, 9));
+        registerRecipe(9, new ItemStack(Material.RED_TULIP), new ItemStack(Material.RED_TULIP, 9));
+        registerRecipe(9, new ItemStack(Material.ORANGE_TULIP), new ItemStack(Material.ORANGE_TULIP, 9));
+        registerRecipe(9, new ItemStack(Material.WHITE_TULIP), new ItemStack(Material.WHITE_TULIP, 9));
+        registerRecipe(9, new ItemStack(Material.PINK_TULIP), new ItemStack(Material.PINK_TULIP, 9));
+        registerRecipe(9, new ItemStack(Material.OXEYE_DAISY), new ItemStack(Material.OXEYE_DAISY, 9));
+        registerRecipe(9, new ItemStack(Material.CORNFLOWER), new ItemStack(Material.CORNFLOWER, 9));
+        registerRecipe(9, new ItemStack(Material.LILY_OF_THE_VALLEY), new ItemStack(Material.LILY_OF_THE_VALLEY, 9));
+        registerRecipe(12, new ItemStack(Material.WITHER_ROSE), new ItemStack(Material.WITHER_ROSE, 6));
+        registerRecipe(12, new ItemStack(Material.SUNFLOWER), new ItemStack(Material.SUNFLOWER, 6));
+        registerRecipe(12, new ItemStack(Material.LILAC), new ItemStack(Material.LILAC, 6));
+        registerRecipe(12, new ItemStack(Material.ROSE_BUSH), new ItemStack(Material.ROSE_BUSH, 6));
+        registerRecipe(12, new ItemStack(Material.PEONY), new ItemStack(Material.PEONY, 6));
 
-        registerRecipe(30, new ItemStack(Material.CARROT), new ItemStack(Material.CARROT, 9));
-        registerRecipe(30, new ItemStack(Material.POTATO), new ItemStack(Material.POTATO, 9));
-        registerRecipe(30, new ItemStack(Material.POISONOUS_POTATO), new ItemStack(Material.POISONOUS_POTATO, 3));
-        registerRecipe(30, new ItemStack(Material.SWEET_BERRIES), new ItemStack(Material.SWEET_BERRIES, 9));
-        registerRecipe(30, new ItemStack[] {new ItemStack(Material.CHORUS_FLOWER)}, new ItemStack[] {new ItemStack(Material.CHORUS_FLOWER , 2), new ItemStack(Material.CHORUS_FRUIT, 6)});
+        registerRecipe(12, new ItemStack(Material.CARROT), new ItemStack(Material.CARROT, 9));
+        registerRecipe(12, new ItemStack(Material.POTATO), new ItemStack(Material.POTATO, 9));
+        registerRecipe(12, new ItemStack(Material.SWEET_BERRIES), new ItemStack(Material.SWEET_BERRIES, 9));
+        registerRecipe(12, new ItemStack(Material.SUGAR_CANE), new ItemStack(Material.SUGAR_CANE, 9));
+        registerRecipe(12, new ItemStack(Material.BAMBOO), new ItemStack(Material.BAMBOO, 9));
+        registerRecipe(12, new ItemStack(Material.CACTUS), new ItemStack(Material.CACTUS, 9));
 
-        registerRecipe(35, new ItemStack(Material.KELP), new ItemStack(Material.KELP, 6));
-        registerRecipe(35, new ItemStack(Material.SUGAR_CANE), new ItemStack(Material.SUGAR_CANE, 6));
-        registerRecipe(35, new ItemStack(Material.BAMBOO), new ItemStack(Material.BAMBOO, 6));
-        registerRecipe(35, new ItemStack(Material.CACTUS), new ItemStack(Material.CACTUS, 6));
-       
-        registerRecipe(40, new ItemStack[] {new ItemStack(Material.OAK_SAPLING)}, new ItemStack[] {new ItemStack(Material.OAK_SAPLING , 9), new ItemStack(Material.OAK_LOG, 18), new ItemStack(Material.APPLE, 6), new ItemStack(Material.OAK_LEAVES, 9)});
-        registerRecipe(40, new ItemStack[] {new ItemStack(Material.BIRCH_SAPLING)}, new ItemStack[] {new ItemStack(Material.BIRCH_SAPLING , 9), new ItemStack(Material.BIRCH_LOG, 18), new ItemStack(Material.APPLE, 6), new ItemStack(Material.BIRCH_LEAVES, 9)});
-        registerRecipe(40, new ItemStack[] {new ItemStack(Material.SPRUCE_SAPLING)}, new ItemStack[] {new ItemStack(Material.SPRUCE_SAPLING , 9), new ItemStack(Material.SPRUCE_LOG, 18), new ItemStack(Material.APPLE, 6), new ItemStack(Material.SPRUCE_LEAVES, 9)});
-        registerRecipe(40, new ItemStack[] {new ItemStack(Material.DARK_OAK_SAPLING)}, new ItemStack[] {new ItemStack(Material.DARK_OAK_SAPLING , 9), new ItemStack(Material.DARK_OAK_LOG, 18), new ItemStack(Material.APPLE, 6), new ItemStack(Material.DARK_OAK_LEAVES, 9)});
-        registerRecipe(40, new ItemStack[] {new ItemStack(Material.JUNGLE_SAPLING)}, new ItemStack[] {new ItemStack(Material.JUNGLE_SAPLING, 9), new ItemStack(Material.JUNGLE_LOG, 18), new ItemStack(Material.APPLE, 6), new ItemStack(Material.JUNGLE_LEAVES, 9)});
-        registerRecipe(40, new ItemStack[] {new ItemStack(Material.ACACIA_SAPLING)}, new ItemStack[] {new ItemStack(Material.ACACIA_SAPLING, 9), new ItemStack(Material.ACACIA_LOG, 18), new ItemStack(Material.APPLE, 6), new ItemStack(Material.ACACIA_LEAVES, 9)});
-        registerRecipe(40, new ItemStack[] {new ItemStack(Material.CRIMSON_FUNGUS)}, new ItemStack[] {new ItemStack(Material.CRIMSON_FUNGUS, 6), new ItemStack(Material.CRIMSON_STEM, 18), new ItemStack(Material.SHROOMLIGHT, 6), new ItemStack(Material.NETHER_WART_BLOCK, 9)});
-        registerRecipe(40, new ItemStack[] {new ItemStack(Material.WARPED_FUNGUS)}, new ItemStack[] {new ItemStack(Material.WARPED_FUNGUS, 6), new ItemStack(Material.WARPED_STEM, 18), new ItemStack(Material.SHROOMLIGHT, 6), new ItemStack(Material.WARPED_WART_BLOCK, 9)});
+        registerRecipe(30, new ItemStack[] {new ItemStack(Material.OAK_SAPLING)}, new ItemStack[] {new ItemStack(Material.OAK_SAPLING , 9), new ItemStack(Material.OAK_LOG, 18), new ItemStack(Material.APPLE, 6), new ItemStack(Material.OAK_LEAVES, 9), new ItemStack(Material.STICK, 6)});
+        registerRecipe(30, new ItemStack[] {new ItemStack(Material.BIRCH_SAPLING)}, new ItemStack[] {new ItemStack(Material.BIRCH_SAPLING , 9), new ItemStack(Material.BIRCH_LOG, 18), new ItemStack(Material.APPLE, 6), new ItemStack(Material.BIRCH_LEAVES, 9), new ItemStack(Material.STICK, 6)});
+        registerRecipe(30, new ItemStack[] {new ItemStack(Material.SPRUCE_SAPLING)}, new ItemStack[] {new ItemStack(Material.SPRUCE_SAPLING , 9), new ItemStack(Material.SPRUCE_LOG, 18), new ItemStack(Material.APPLE, 6), new ItemStack(Material.SPRUCE_LEAVES, 9), new ItemStack(Material.STICK, 6)});
+        registerRecipe(30, new ItemStack[] {new ItemStack(Material.DARK_OAK_SAPLING)}, new ItemStack[] {new ItemStack(Material.DARK_OAK_SAPLING , 9), new ItemStack(Material.DARK_OAK_LOG, 18), new ItemStack(Material.APPLE, 6), new ItemStack(Material.DARK_OAK_LEAVES, 9), new ItemStack(Material.STICK, 6)});
+        registerRecipe(30, new ItemStack[] {new ItemStack(Material.JUNGLE_SAPLING)}, new ItemStack[] {new ItemStack(Material.JUNGLE_SAPLING, 9), new ItemStack(Material.JUNGLE_LOG, 18), new ItemStack(Material.APPLE, 6), new ItemStack(Material.JUNGLE_LEAVES, 9), new ItemStack(Material.STICK, 6)});
+        registerRecipe(30, new ItemStack[] {new ItemStack(Material.ACACIA_SAPLING)}, new ItemStack[] {new ItemStack(Material.ACACIA_SAPLING, 9), new ItemStack(Material.ACACIA_LOG, 18), new ItemStack(Material.APPLE, 6), new ItemStack(Material.ACACIA_LEAVES, 9), new ItemStack(Material.STICK, 6)});
 
     }
 
@@ -150,7 +158,7 @@ public class GrowthChamberMK2 extends AMachine {
 
     @Override
     public ItemStack getProgressBar() {
-        return new ItemStack(Material.IRON_HOE);
+        return new ItemStack(Material.DIAMOND_HOE);
     }
     
     @Override

--- a/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberNether.java
+++ b/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberNether.java
@@ -1,0 +1,47 @@
+package me.profelements.dynatech.items.electric;
+
+import me.mrCookieSlime.Slimefun.Lists.RecipeType;
+import me.mrCookieSlime.Slimefun.Objects.Category;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineRecipe;
+import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
+import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
+import me.profelements.dynatech.DynaTech;
+import me.profelements.dynatech.items.electric.abstracts.AMachine;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+public class GrowthChamberNether extends AMachine {
+
+    public GrowthChamberNether(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(category, item, recipeType, recipe);
+
+    }
+
+    @Override
+    protected void registerDefaultRecipes() {
+
+        registerRecipe(20, new ItemStack(Material.NETHER_WART), new ItemStack(Material.NETHER_WART, 4));
+        registerRecipe(20, new ItemStack(Material.WEEPING_VINES), new ItemStack(Material.WEEPING_VINES, 4));
+        registerRecipe(20, new ItemStack(Material.TWISTING_VINES), new ItemStack(Material.TWISTING_VINES, 4));
+        registerRecipe(20, new ItemStack(Material.CRIMSON_ROOTS), new ItemStack(Material.CRIMSON_ROOTS, 4));
+        registerRecipe(20, new ItemStack(Material.WARPED_ROOTS), new ItemStack(Material.WARPED_ROOTS, 4));
+        registerRecipe(20, new ItemStack(Material.NETHER_SPROUTS), new ItemStack(Material.NETHER_SPROUTS, 4));
+
+        registerRecipe(40, new ItemStack[] {new ItemStack(Material.CRIMSON_FUNGUS)}, new ItemStack[] {new ItemStack(Material.CRIMSON_FUNGUS, 2), new ItemStack(Material.CRIMSON_STEM, 6)});
+        registerRecipe(40, new ItemStack[] {new ItemStack(Material.WARPED_FUNGUS)}, new ItemStack[] {new ItemStack(Material.WARPED_FUNGUS, 2), new ItemStack(Material.WARPED_STEM, 6)});
+
+    }
+    
+    @Override
+    public ItemStack getProgressBar() {
+        return new ItemStack(Material.NETHERRACK);
+    }
+
+    @Override
+    public String getMachineIdentifier() {
+        return "GROWTH_CHAMBER_NETHER";
+    }
+
+}

--- a/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberNether.java
+++ b/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberNether.java
@@ -22,15 +22,15 @@ public class GrowthChamberNether extends AMachine {
     @Override
     protected void registerDefaultRecipes() {
 
-        registerRecipe(20, new ItemStack(Material.NETHER_WART), new ItemStack(Material.NETHER_WART, 4));
-        registerRecipe(20, new ItemStack(Material.WEEPING_VINES), new ItemStack(Material.WEEPING_VINES, 4));
-        registerRecipe(20, new ItemStack(Material.TWISTING_VINES), new ItemStack(Material.TWISTING_VINES, 4));
-        registerRecipe(20, new ItemStack(Material.CRIMSON_ROOTS), new ItemStack(Material.CRIMSON_ROOTS, 4));
-        registerRecipe(20, new ItemStack(Material.WARPED_ROOTS), new ItemStack(Material.WARPED_ROOTS, 4));
-        registerRecipe(20, new ItemStack(Material.NETHER_SPROUTS), new ItemStack(Material.NETHER_SPROUTS, 4));
+        registerRecipe(12, new ItemStack(Material.NETHER_WART), new ItemStack(Material.NETHER_WART, 4));
+        registerRecipe(9, new ItemStack(Material.WEEPING_VINES), new ItemStack(Material.WEEPING_VINES, 4));
+        registerRecipe(9, new ItemStack(Material.TWISTING_VINES), new ItemStack(Material.TWISTING_VINES, 4));
+        registerRecipe(9, new ItemStack(Material.CRIMSON_ROOTS), new ItemStack(Material.CRIMSON_ROOTS, 4));
+        registerRecipe(9, new ItemStack(Material.WARPED_ROOTS), new ItemStack(Material.WARPED_ROOTS, 4));
+        registerRecipe(9, new ItemStack(Material.NETHER_SPROUTS), new ItemStack(Material.NETHER_SPROUTS, 4));
 
-        registerRecipe(40, new ItemStack[] {new ItemStack(Material.CRIMSON_FUNGUS)}, new ItemStack[] {new ItemStack(Material.CRIMSON_FUNGUS, 2), new ItemStack(Material.CRIMSON_STEM, 6)});
-        registerRecipe(40, new ItemStack[] {new ItemStack(Material.WARPED_FUNGUS)}, new ItemStack[] {new ItemStack(Material.WARPED_FUNGUS, 2), new ItemStack(Material.WARPED_STEM, 6)});
+        registerRecipe(30, new ItemStack[] {new ItemStack(Material.CRIMSON_FUNGUS)}, new ItemStack[] {new ItemStack(Material.CRIMSON_FUNGUS, 2), new ItemStack(Material.CRIMSON_STEM, 6)});
+        registerRecipe(30, new ItemStack[] {new ItemStack(Material.WARPED_FUNGUS)}, new ItemStack[] {new ItemStack(Material.WARPED_FUNGUS, 2), new ItemStack(Material.WARPED_STEM, 6)});
 
     }
     

--- a/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberNetherMK2.java
+++ b/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberNetherMK2.java
@@ -1,0 +1,47 @@
+package me.profelements.dynatech.items.electric;
+
+import me.mrCookieSlime.Slimefun.Lists.RecipeType;
+import me.mrCookieSlime.Slimefun.Objects.Category;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineRecipe;
+import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
+import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
+import me.profelements.dynatech.DynaTech;
+import me.profelements.dynatech.items.electric.abstracts.AMachine;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+public class GrowthChamberNetherMK2 extends AMachine {
+
+    public GrowthChamberNetherMK2(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(category, item, recipeType, recipe);
+
+    }
+
+    @Override
+    protected void registerDefaultRecipes() {
+
+        registerRecipe(20, new ItemStack(Material.NETHER_WART), new ItemStack(Material.NETHER_WART, 12));
+        registerRecipe(20, new ItemStack(Material.WEEPING_VINES), new ItemStack(Material.WEEPING_VINES, 12));
+        registerRecipe(20, new ItemStack(Material.TWISTING_VINES), new ItemStack(Material.TWISTING_VINES, 12));
+        registerRecipe(20, new ItemStack(Material.CRIMSON_ROOTS), new ItemStack(Material.CRIMSON_ROOTS, 12));
+        registerRecipe(20, new ItemStack(Material.WARPED_ROOTS), new ItemStack(Material.WARPED_ROOTS, 12));
+        registerRecipe(20, new ItemStack(Material.NETHER_SPROUTS), new ItemStack(Material.NETHER_SPROUTS, 12));
+
+        registerRecipe(40, new ItemStack[] {new ItemStack(Material.CRIMSON_FUNGUS)}, new ItemStack[] {new ItemStack(Material.CRIMSON_FUNGUS, 6), new ItemStack(Material.CRIMSON_STEM, 18)});
+        registerRecipe(40, new ItemStack[] {new ItemStack(Material.WARPED_FUNGUS)}, new ItemStack[] {new ItemStack(Material.WARPED_FUNGUS, 6), new ItemStack(Material.WARPED_STEM, 18)});
+
+    }
+    
+    @Override
+    public ItemStack getProgressBar() {
+        return new ItemStack(Material.NETHERRACK);
+    }
+
+    @Override
+    public String getMachineIdentifier() {
+        return "GROWTH_CHAMBER_NETHER_MK2";
+    }
+
+}

--- a/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberNetherMK2.java
+++ b/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberNetherMK2.java
@@ -29,15 +29,15 @@ public class GrowthChamberNetherMK2 extends AMachine {
     @Override
     protected void registerDefaultRecipes() {
 
-        registerRecipe(20, new ItemStack(Material.NETHER_WART), new ItemStack(Material.NETHER_WART, 12));
-        registerRecipe(20, new ItemStack(Material.WEEPING_VINES), new ItemStack(Material.WEEPING_VINES, 12));
-        registerRecipe(20, new ItemStack(Material.TWISTING_VINES), new ItemStack(Material.TWISTING_VINES, 12));
-        registerRecipe(20, new ItemStack(Material.CRIMSON_ROOTS), new ItemStack(Material.CRIMSON_ROOTS, 12));
-        registerRecipe(20, new ItemStack(Material.WARPED_ROOTS), new ItemStack(Material.WARPED_ROOTS, 12));
-        registerRecipe(20, new ItemStack(Material.NETHER_SPROUTS), new ItemStack(Material.NETHER_SPROUTS, 12));
+        registerRecipe(12, new ItemStack(Material.NETHER_WART), new ItemStack(Material.NETHER_WART, 12));
+        registerRecipe(9, new ItemStack(Material.WEEPING_VINES), new ItemStack(Material.WEEPING_VINES, 12));
+        registerRecipe(9, new ItemStack(Material.TWISTING_VINES), new ItemStack(Material.TWISTING_VINES, 12));
+        registerRecipe(9, new ItemStack(Material.CRIMSON_ROOTS), new ItemStack(Material.CRIMSON_ROOTS, 12));
+        registerRecipe(9, new ItemStack(Material.WARPED_ROOTS), new ItemStack(Material.WARPED_ROOTS, 12));
+        registerRecipe(9, new ItemStack(Material.NETHER_SPROUTS), new ItemStack(Material.NETHER_SPROUTS, 12));
 
-        registerRecipe(40, new ItemStack[] {new ItemStack(Material.CRIMSON_FUNGUS)}, new ItemStack[] {new ItemStack(Material.CRIMSON_FUNGUS, 6), new ItemStack(Material.CRIMSON_STEM, 18), new ItemStack(Material.SHROOMLIGHT, 6), new ItemStack(Material.NETHER_WART_BLOCK, 12)});
-        registerRecipe(40, new ItemStack[] {new ItemStack(Material.WARPED_FUNGUS)}, new ItemStack[] {new ItemStack(Material.WARPED_FUNGUS, 6), new ItemStack(Material.WARPED_STEM, 18), new ItemStack(Material.SHROOMLIGHT, 6), new ItemStack(Material.WARPED_WART_BLOCK, 12)});
+        registerRecipe(30, new ItemStack[] {new ItemStack(Material.CRIMSON_FUNGUS)}, new ItemStack[] {new ItemStack(Material.CRIMSON_FUNGUS, 6), new ItemStack(Material.CRIMSON_STEM, 18), new ItemStack(Material.SHROOMLIGHT, 6), new ItemStack(Material.NETHER_WART_BLOCK, 12)});
+        registerRecipe(30, new ItemStack[] {new ItemStack(Material.WARPED_FUNGUS)}, new ItemStack[] {new ItemStack(Material.WARPED_FUNGUS, 6), new ItemStack(Material.WARPED_STEM, 18), new ItemStack(Material.SHROOMLIGHT, 6), new ItemStack(Material.WARPED_WART_BLOCK, 12)});
 
     }
 

--- a/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberNetherMK2.java
+++ b/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberNetherMK2.java
@@ -73,7 +73,7 @@ public class GrowthChamberNetherMK2 extends AMachine {
 
     @Override
     public ItemStack getProgressBar() {
-        return new ItemStack(Material.CONDUIT);
+        return new ItemStack(Material.NETHERRACK);
     }
     
     @Override

--- a/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberNetherMK2.java
+++ b/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberNetherMK2.java
@@ -1,5 +1,8 @@
 package me.profelements.dynatech.items.electric;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
@@ -13,7 +16,11 @@ import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 
 public class GrowthChamberNetherMK2 extends AMachine {
-
+    
+    private static int[] BORDER = new int[] {};
+    private static int[] BORDER_IN = new int[] {0,8,9,10,11,12,14,15,16,17};
+    private static int[] BORDER_OUT = new int[] {18,19,20,21,22,23,24,25,26,27,35,36,44,45,53};
+    
     public GrowthChamberNetherMK2(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(category, item, recipeType, recipe);
 
@@ -29,19 +36,49 @@ public class GrowthChamberNetherMK2 extends AMachine {
         registerRecipe(20, new ItemStack(Material.WARPED_ROOTS), new ItemStack(Material.WARPED_ROOTS, 12));
         registerRecipe(20, new ItemStack(Material.NETHER_SPROUTS), new ItemStack(Material.NETHER_SPROUTS, 12));
 
-        registerRecipe(40, new ItemStack[] {new ItemStack(Material.CRIMSON_FUNGUS)}, new ItemStack[] {new ItemStack(Material.CRIMSON_FUNGUS, 6), new ItemStack(Material.CRIMSON_STEM, 18)});
-        registerRecipe(40, new ItemStack[] {new ItemStack(Material.WARPED_FUNGUS)}, new ItemStack[] {new ItemStack(Material.WARPED_FUNGUS, 6), new ItemStack(Material.WARPED_STEM, 18)});
+        registerRecipe(40, new ItemStack[] {new ItemStack(Material.CRIMSON_FUNGUS)}, new ItemStack[] {new ItemStack(Material.CRIMSON_FUNGUS, 6), new ItemStack(Material.CRIMSON_STEM, 18), new ItemStack(Material.SHROOMLIGHT, 6), new ItemStack(Material.NETHER_WART_BLOCK, 12)});
+        registerRecipe(40, new ItemStack[] {new ItemStack(Material.WARPED_FUNGUS)}, new ItemStack[] {new ItemStack(Material.WARPED_FUNGUS, 6), new ItemStack(Material.WARPED_STEM, 18), new ItemStack(Material.SHROOMLIGHT, 6), new ItemStack(Material.WARPED_WART_BLOCK, 12)});
 
+    }
+
+    @Override
+    public boolean isGraphical() {
+        return true;
     }
     
-    @Override
-    public ItemStack getProgressBar() {
-        return new ItemStack(Material.NETHERRACK);
-    }
-
     @Override
     public String getMachineIdentifier() {
         return "GROWTH_CHAMBER_NETHER_MK2";
     }
 
+
+    @Override
+    public List<int[]> getBorders() {
+        List<int[]> borders = new ArrayList<>();
+        borders.add(BORDER);
+        borders.add(BORDER_IN);
+        borders.add(BORDER_OUT);
+        
+        return borders;
+    }
+    
+    @Override
+    public int[] getInputSlots() {
+        return new int[] {1,2,3,4,5,6,7};
+    }
+    @Override
+    public int[] getOutputSlots() {
+        return new int[] {28,29,30,31,32,33,34,37,38,39,40,41,42,43,46,47,48,49,50,51,52};
+    }
+
+    @Override
+    public ItemStack getProgressBar() {
+        return new ItemStack(Material.CONDUIT);
+    }
+    
+    @Override
+    public int getProgressBarSlot() {
+        return 13;
+    }
+    
 }

--- a/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberOcean.java
+++ b/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberOcean.java
@@ -1,0 +1,84 @@
+package me.profelements.dynatech.items.electric;
+
+import me.mrCookieSlime.Slimefun.Lists.RecipeType;
+import me.mrCookieSlime.Slimefun.Objects.Category;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineRecipe;
+import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
+import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
+import me.profelements.dynatech.DynaTech;
+import me.profelements.dynatech.items.electric.abstracts.AMachine;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+public class GrowthChamberOcean extends AMachine {
+
+    public GrowthChamberOcean(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(category, item, recipeType, recipe);
+
+    }
+
+    @Override
+    protected void registerDefaultRecipes() {
+
+        registerRecipe(20, new ItemStack(Material.LILY_PAD), new ItemStack(Material.LILY_PAD, 3));
+        registerRecipe(20, new ItemStack(Material.SEA_PICKLE), new ItemStack(Material.SEA_PICKLE, 3));
+        registerRecipe(20, new ItemStack(Material.SEAGRASS), new ItemStack(Material.SEAGRASS, 4));
+        registerRecipe(0, new ItemStack(Material.KELP), new ItemStack(Material.KELP, 3));
+    // Coral blocks
+        // Brings dead coral blocks back to life!
+        registerRecipe(20, new ItemStack(Material.DEAD_TUBE_CORAL_BLOCK), new ItemStack(Material.TUBE_CORAL_BLOCK, 1));
+        registerRecipe(20, new ItemStack(Material.DEAD_BRAIN_CORAL_BLOCK), new ItemStack(Material.BRAIN_CORAL_BLOCK, 1));
+        registerRecipe(20, new ItemStack(Material.DEAD_BUBBLE_CORAL_BLOCK), new ItemStack(Material.BUBBLE_CORAL_BLOCK, 1));
+        registerRecipe(20, new ItemStack(Material.DEAD_FIRE_CORAL_BLOCK), new ItemStack(Material.FIRE_CORAL_BLOCK, 1));
+        registerRecipe(20, new ItemStack(Material.DEAD_HORN_CORAL_BLOCK), new ItemStack(Material.HORN_CORAL_BLOCK, 1));
+        // Block duplication
+        registerRecipe(20, new ItemStack(Material.TUBE_CORAL_BLOCK), new ItemStack(Material.TUBE_CORAL_BLOCK, 2));
+        registerRecipe(20, new ItemStack(Material.BRAIN_CORAL_BLOCK), new ItemStack(Material.BRAIN_CORAL_BLOCK, 2));
+        registerRecipe(20, new ItemStack(Material.BUBBLE_CORAL_BLOCK), new ItemStack(Material.BUBBLE_CORAL_BLOCK, 2));
+        registerRecipe(20, new ItemStack(Material.FIRE_CORAL_BLOCK), new ItemStack(Material.FIRE_CORAL_BLOCK, 2));
+        registerRecipe(20, new ItemStack(Material.HORN_CORAL_BLOCK), new ItemStack(Material.HORN_CORAL_BLOCK, 2));
+
+    // Coral
+        // Revive for coral
+        registerRecipe(20, new ItemStack(Material.DEAD_TUBE_CORAL), new ItemStack(Material.TUBE_CORAL, 1));
+        registerRecipe(20, new ItemStack(Material.DEAD_BRAIN_CORAL), new ItemStack(Material.BRAIN_CORAL, 1));
+        registerRecipe(20, new ItemStack(Material.DEAD_BUBBLE_CORAL), new ItemStack(Material.BUBBLE_CORAL, 1));
+        registerRecipe(20, new ItemStack(Material.DEAD_FIRE_CORAL), new ItemStack(Material.FIRE_CORAL, 1));
+        registerRecipe(20, new ItemStack(Material.DEAD_HORN_CORAL), new ItemStack(Material.HORN_CORAL, 1));
+        // Coral duplication
+        registerRecipe(20, new ItemStack(Material.TUBE_CORAL), new ItemStack(Material.TUBE_CORAL, 2));
+        registerRecipe(20, new ItemStack(Material.BRAIN_CORAL), new ItemStack(Material.BRAIN_CORAL, 2));
+        registerRecipe(20, new ItemStack(Material.BUBBLE_CORAL), new ItemStack(Material.BUBBLE_CORAL, 2));
+        registerRecipe(20, new ItemStack(Material.FIRE_CORAL), new ItemStack(Material.FIRE_CORAL, 2));
+        registerRecipe(20, new ItemStack(Material.HORN_CORAL), new ItemStack(Material.HORN_CORAL, 2));
+
+    // Coral fans
+        // Medical attention for the fans
+        registerRecipe(20, new ItemStack(Material.DEAD_TUBE_CORAL_FAN), new ItemStack(Material.TUBE_CORAL_FAN, 1));
+        registerRecipe(20, new ItemStack(Material.DEAD_BRAIN_CORAL_FAN), new ItemStack(Material.BRAIN_CORAL_FAN, 1));
+        registerRecipe(20, new ItemStack(Material.DEAD_BUBBLE_CORAL_FAN), new ItemStack(Material.BUBBLE_CORAL_FAN, 1));
+        registerRecipe(20, new ItemStack(Material.DEAD_FIRE_CORAL_FAN), new ItemStack(Material.FIRE_CORAL_FAN, 1));
+        registerRecipe(20, new ItemStack(Material.DEAD_HORN_CORAL_FAN), new ItemStack(Material.HORN_CORAL_FAN, 1));
+        // Fan duplication
+        registerRecipe(20, new ItemStack(Material.TUBE_CORAL_FAN), new ItemStack(Material.TUBE_CORAL_FAN, 2));
+        registerRecipe(20, new ItemStack(Material.BRAIN_CORAL_FAN), new ItemStack(Material.BRAIN_CORAL_FAN, 2));
+        registerRecipe(20, new ItemStack(Material.BUBBLE_CORAL_FAN), new ItemStack(Material.BUBBLE_CORAL_FAN, 2));
+        registerRecipe(20, new ItemStack(Material.FIRE_CORAL_FAN), new ItemStack(Material.FIRE_CORAL_FAN, 2));
+        registerRecipe(20, new ItemStack(Material.HORN_CORAL_FAN), new ItemStack(Material.HORN_CORAL_FAN, 2));
+
+
+    }
+    
+    @Override
+    public ItemStack getProgressBar() {
+        return new ItemStack(Material.CONDUIT);
+    }
+
+    @Override
+    public String getMachineIdentifier() {
+        return "GROWTH_CHAMBER_OCEAN";
+    }
+
+}

--- a/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberOcean.java
+++ b/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberOcean.java
@@ -22,51 +22,51 @@ public class GrowthChamberOcean extends AMachine {
     @Override
     protected void registerDefaultRecipes() {
 
-        registerRecipe(20, new ItemStack(Material.LILY_PAD), new ItemStack(Material.LILY_PAD, 3));
-        registerRecipe(20, new ItemStack(Material.SEA_PICKLE), new ItemStack(Material.SEA_PICKLE, 3));
-        registerRecipe(20, new ItemStack(Material.SEAGRASS), new ItemStack(Material.SEAGRASS, 4));
-        registerRecipe(0, new ItemStack(Material.KELP), new ItemStack(Material.KELP, 3));
+        registerRecipe(9, new ItemStack(Material.LILY_PAD), new ItemStack(Material.LILY_PAD, 3));
+        registerRecipe(9, new ItemStack(Material.SEA_PICKLE), new ItemStack(Material.SEA_PICKLE, 3));
+        registerRecipe(12, new ItemStack(Material.SEAGRASS), new ItemStack(Material.SEAGRASS, 4));
+        registerRecipe(9, new ItemStack(Material.KELP), new ItemStack(Material.KELP, 3));
     // Coral blocks
         // Brings dead coral blocks back to life!
-        registerRecipe(20, new ItemStack(Material.DEAD_TUBE_CORAL_BLOCK), new ItemStack(Material.TUBE_CORAL_BLOCK, 1));
-        registerRecipe(20, new ItemStack(Material.DEAD_BRAIN_CORAL_BLOCK), new ItemStack(Material.BRAIN_CORAL_BLOCK, 1));
-        registerRecipe(20, new ItemStack(Material.DEAD_BUBBLE_CORAL_BLOCK), new ItemStack(Material.BUBBLE_CORAL_BLOCK, 1));
-        registerRecipe(20, new ItemStack(Material.DEAD_FIRE_CORAL_BLOCK), new ItemStack(Material.FIRE_CORAL_BLOCK, 1));
-        registerRecipe(20, new ItemStack(Material.DEAD_HORN_CORAL_BLOCK), new ItemStack(Material.HORN_CORAL_BLOCK, 1));
+        registerRecipe(9, new ItemStack(Material.DEAD_TUBE_CORAL_BLOCK), new ItemStack(Material.TUBE_CORAL_BLOCK, 1));
+        registerRecipe(9, new ItemStack(Material.DEAD_BRAIN_CORAL_BLOCK), new ItemStack(Material.BRAIN_CORAL_BLOCK, 1));
+        registerRecipe(9, new ItemStack(Material.DEAD_BUBBLE_CORAL_BLOCK), new ItemStack(Material.BUBBLE_CORAL_BLOCK, 1));
+        registerRecipe(9, new ItemStack(Material.DEAD_FIRE_CORAL_BLOCK), new ItemStack(Material.FIRE_CORAL_BLOCK, 1));
+        registerRecipe(9, new ItemStack(Material.DEAD_HORN_CORAL_BLOCK), new ItemStack(Material.HORN_CORAL_BLOCK, 1));
         // Block duplication
-        registerRecipe(20, new ItemStack(Material.TUBE_CORAL_BLOCK), new ItemStack(Material.TUBE_CORAL_BLOCK, 2));
-        registerRecipe(20, new ItemStack(Material.BRAIN_CORAL_BLOCK), new ItemStack(Material.BRAIN_CORAL_BLOCK, 2));
-        registerRecipe(20, new ItemStack(Material.BUBBLE_CORAL_BLOCK), new ItemStack(Material.BUBBLE_CORAL_BLOCK, 2));
-        registerRecipe(20, new ItemStack(Material.FIRE_CORAL_BLOCK), new ItemStack(Material.FIRE_CORAL_BLOCK, 2));
-        registerRecipe(20, new ItemStack(Material.HORN_CORAL_BLOCK), new ItemStack(Material.HORN_CORAL_BLOCK, 2));
+        registerRecipe(12, new ItemStack(Material.TUBE_CORAL_BLOCK), new ItemStack(Material.TUBE_CORAL_BLOCK, 2));
+        registerRecipe(12, new ItemStack(Material.BRAIN_CORAL_BLOCK), new ItemStack(Material.BRAIN_CORAL_BLOCK, 2));
+        registerRecipe(12, new ItemStack(Material.BUBBLE_CORAL_BLOCK), new ItemStack(Material.BUBBLE_CORAL_BLOCK, 2));
+        registerRecipe(12, new ItemStack(Material.FIRE_CORAL_BLOCK), new ItemStack(Material.FIRE_CORAL_BLOCK, 2));
+        registerRecipe(12, new ItemStack(Material.HORN_CORAL_BLOCK), new ItemStack(Material.HORN_CORAL_BLOCK, 2));
 
     // Coral
         // Revive for coral
-        registerRecipe(20, new ItemStack(Material.DEAD_TUBE_CORAL), new ItemStack(Material.TUBE_CORAL, 1));
-        registerRecipe(20, new ItemStack(Material.DEAD_BRAIN_CORAL), new ItemStack(Material.BRAIN_CORAL, 1));
-        registerRecipe(20, new ItemStack(Material.DEAD_BUBBLE_CORAL), new ItemStack(Material.BUBBLE_CORAL, 1));
-        registerRecipe(20, new ItemStack(Material.DEAD_FIRE_CORAL), new ItemStack(Material.FIRE_CORAL, 1));
-        registerRecipe(20, new ItemStack(Material.DEAD_HORN_CORAL), new ItemStack(Material.HORN_CORAL, 1));
+        registerRecipe(9, new ItemStack(Material.DEAD_TUBE_CORAL), new ItemStack(Material.TUBE_CORAL, 1));
+        registerRecipe(9, new ItemStack(Material.DEAD_BRAIN_CORAL), new ItemStack(Material.BRAIN_CORAL, 1));
+        registerRecipe(9, new ItemStack(Material.DEAD_BUBBLE_CORAL), new ItemStack(Material.BUBBLE_CORAL, 1));
+        registerRecipe(9, new ItemStack(Material.DEAD_FIRE_CORAL), new ItemStack(Material.FIRE_CORAL, 1));
+        registerRecipe(9, new ItemStack(Material.DEAD_HORN_CORAL), new ItemStack(Material.HORN_CORAL, 1));
         // Coral duplication
-        registerRecipe(20, new ItemStack(Material.TUBE_CORAL), new ItemStack(Material.TUBE_CORAL, 2));
-        registerRecipe(20, new ItemStack(Material.BRAIN_CORAL), new ItemStack(Material.BRAIN_CORAL, 2));
-        registerRecipe(20, new ItemStack(Material.BUBBLE_CORAL), new ItemStack(Material.BUBBLE_CORAL, 2));
-        registerRecipe(20, new ItemStack(Material.FIRE_CORAL), new ItemStack(Material.FIRE_CORAL, 2));
-        registerRecipe(20, new ItemStack(Material.HORN_CORAL), new ItemStack(Material.HORN_CORAL, 2));
+        registerRecipe(12, new ItemStack(Material.TUBE_CORAL), new ItemStack(Material.TUBE_CORAL, 2));
+        registerRecipe(12, new ItemStack(Material.BRAIN_CORAL), new ItemStack(Material.BRAIN_CORAL, 2));
+        registerRecipe(12, new ItemStack(Material.BUBBLE_CORAL), new ItemStack(Material.BUBBLE_CORAL, 2));
+        registerRecipe(12, new ItemStack(Material.FIRE_CORAL), new ItemStack(Material.FIRE_CORAL, 2));
+        registerRecipe(12, new ItemStack(Material.HORN_CORAL), new ItemStack(Material.HORN_CORAL, 2));
 
     // Coral fans
         // Medical attention for the fans
-        registerRecipe(20, new ItemStack(Material.DEAD_TUBE_CORAL_FAN), new ItemStack(Material.TUBE_CORAL_FAN, 1));
-        registerRecipe(20, new ItemStack(Material.DEAD_BRAIN_CORAL_FAN), new ItemStack(Material.BRAIN_CORAL_FAN, 1));
-        registerRecipe(20, new ItemStack(Material.DEAD_BUBBLE_CORAL_FAN), new ItemStack(Material.BUBBLE_CORAL_FAN, 1));
-        registerRecipe(20, new ItemStack(Material.DEAD_FIRE_CORAL_FAN), new ItemStack(Material.FIRE_CORAL_FAN, 1));
-        registerRecipe(20, new ItemStack(Material.DEAD_HORN_CORAL_FAN), new ItemStack(Material.HORN_CORAL_FAN, 1));
+        registerRecipe(9, new ItemStack(Material.DEAD_TUBE_CORAL_FAN), new ItemStack(Material.TUBE_CORAL_FAN, 1));
+        registerRecipe(9, new ItemStack(Material.DEAD_BRAIN_CORAL_FAN), new ItemStack(Material.BRAIN_CORAL_FAN, 1));
+        registerRecipe(9, new ItemStack(Material.DEAD_BUBBLE_CORAL_FAN), new ItemStack(Material.BUBBLE_CORAL_FAN, 1));
+        registerRecipe(9, new ItemStack(Material.DEAD_FIRE_CORAL_FAN), new ItemStack(Material.FIRE_CORAL_FAN, 1));
+        registerRecipe(9, new ItemStack(Material.DEAD_HORN_CORAL_FAN), new ItemStack(Material.HORN_CORAL_FAN, 1));
         // Fan duplication
-        registerRecipe(20, new ItemStack(Material.TUBE_CORAL_FAN), new ItemStack(Material.TUBE_CORAL_FAN, 2));
-        registerRecipe(20, new ItemStack(Material.BRAIN_CORAL_FAN), new ItemStack(Material.BRAIN_CORAL_FAN, 2));
-        registerRecipe(20, new ItemStack(Material.BUBBLE_CORAL_FAN), new ItemStack(Material.BUBBLE_CORAL_FAN, 2));
-        registerRecipe(20, new ItemStack(Material.FIRE_CORAL_FAN), new ItemStack(Material.FIRE_CORAL_FAN, 2));
-        registerRecipe(20, new ItemStack(Material.HORN_CORAL_FAN), new ItemStack(Material.HORN_CORAL_FAN, 2));
+        registerRecipe(12, new ItemStack(Material.TUBE_CORAL_FAN), new ItemStack(Material.TUBE_CORAL_FAN, 2));
+        registerRecipe(12, new ItemStack(Material.BRAIN_CORAL_FAN), new ItemStack(Material.BRAIN_CORAL_FAN, 2));
+        registerRecipe(12, new ItemStack(Material.BUBBLE_CORAL_FAN), new ItemStack(Material.BUBBLE_CORAL_FAN, 2));
+        registerRecipe(12, new ItemStack(Material.FIRE_CORAL_FAN), new ItemStack(Material.FIRE_CORAL_FAN, 2));
+        registerRecipe(12, new ItemStack(Material.HORN_CORAL_FAN), new ItemStack(Material.HORN_CORAL_FAN, 2));
 
 
     }

--- a/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberOceanMK2.java
+++ b/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberOceanMK2.java
@@ -29,51 +29,51 @@ public class GrowthChamberOceanMK2 extends AMachine {
     @Override
     protected void registerDefaultRecipes() {
 
-        registerRecipe(20, new ItemStack(Material.LILY_PAD), new ItemStack(Material.LILY_PAD, 9));
-        registerRecipe(20, new ItemStack(Material.SEA_PICKLE), new ItemStack(Material.SEA_PICKLE, 9));
-        registerRecipe(20, new ItemStack(Material.SEAGRASS), new ItemStack(Material.SEAGRASS, 12));
-        registerRecipe(0, new ItemStack(Material.KELP), new ItemStack(Material.KELP, 9));
+        registerRecipe(9, new ItemStack(Material.LILY_PAD), new ItemStack(Material.LILY_PAD, 9));
+        registerRecipe(9, new ItemStack(Material.SEA_PICKLE), new ItemStack(Material.SEA_PICKLE, 9));
+        registerRecipe(12, new ItemStack(Material.SEAGRASS), new ItemStack(Material.SEAGRASS, 12));
+        registerRecipe(9, new ItemStack(Material.KELP), new ItemStack(Material.KELP, 9));
     // Coral blocks
         // Brings dead coral blocks back to life!
-        registerRecipe(20, new ItemStack(Material.DEAD_TUBE_CORAL_BLOCK), new ItemStack(Material.TUBE_CORAL_BLOCK, 3));
-        registerRecipe(20, new ItemStack(Material.DEAD_BRAIN_CORAL_BLOCK), new ItemStack(Material.BRAIN_CORAL_BLOCK, 3));
-        registerRecipe(20, new ItemStack(Material.DEAD_BUBBLE_CORAL_BLOCK), new ItemStack(Material.BUBBLE_CORAL_BLOCK, 3));
-        registerRecipe(20, new ItemStack(Material.DEAD_FIRE_CORAL_BLOCK), new ItemStack(Material.FIRE_CORAL_BLOCK, 3));
-        registerRecipe(20, new ItemStack(Material.DEAD_HORN_CORAL_BLOCK), new ItemStack(Material.HORN_CORAL_BLOCK, 3));
+        registerRecipe(9, new ItemStack(Material.DEAD_TUBE_CORAL_BLOCK), new ItemStack(Material.TUBE_CORAL_BLOCK, 3));
+        registerRecipe(9, new ItemStack(Material.DEAD_BRAIN_CORAL_BLOCK), new ItemStack(Material.BRAIN_CORAL_BLOCK, 3));
+        registerRecipe(9, new ItemStack(Material.DEAD_BUBBLE_CORAL_BLOCK), new ItemStack(Material.BUBBLE_CORAL_BLOCK, 3));
+        registerRecipe(9, new ItemStack(Material.DEAD_FIRE_CORAL_BLOCK), new ItemStack(Material.FIRE_CORAL_BLOCK, 3));
+        registerRecipe(9, new ItemStack(Material.DEAD_HORN_CORAL_BLOCK), new ItemStack(Material.HORN_CORAL_BLOCK, 3));
         // Block duplication
-        registerRecipe(20, new ItemStack(Material.TUBE_CORAL_BLOCK), new ItemStack(Material.TUBE_CORAL_BLOCK, 6));
-        registerRecipe(20, new ItemStack(Material.BRAIN_CORAL_BLOCK), new ItemStack(Material.BRAIN_CORAL_BLOCK, 6));
-        registerRecipe(20, new ItemStack(Material.BUBBLE_CORAL_BLOCK), new ItemStack(Material.BUBBLE_CORAL_BLOCK, 6));
-        registerRecipe(20, new ItemStack(Material.FIRE_CORAL_BLOCK), new ItemStack(Material.FIRE_CORAL_BLOCK, 6));
-        registerRecipe(20, new ItemStack(Material.HORN_CORAL_BLOCK), new ItemStack(Material.HORN_CORAL_BLOCK, 6));
+        registerRecipe(12, new ItemStack(Material.TUBE_CORAL_BLOCK), new ItemStack(Material.TUBE_CORAL_BLOCK, 6));
+        registerRecipe(12, new ItemStack(Material.BRAIN_CORAL_BLOCK), new ItemStack(Material.BRAIN_CORAL_BLOCK, 6));
+        registerRecipe(12, new ItemStack(Material.BUBBLE_CORAL_BLOCK), new ItemStack(Material.BUBBLE_CORAL_BLOCK, 6));
+        registerRecipe(12, new ItemStack(Material.FIRE_CORAL_BLOCK), new ItemStack(Material.FIRE_CORAL_BLOCK, 6));
+        registerRecipe(12, new ItemStack(Material.HORN_CORAL_BLOCK), new ItemStack(Material.HORN_CORAL_BLOCK, 6));
 
     // Coral
         // Revive for coral
-        registerRecipe(20, new ItemStack(Material.DEAD_TUBE_CORAL), new ItemStack(Material.TUBE_CORAL, 3));
-        registerRecipe(20, new ItemStack(Material.DEAD_BRAIN_CORAL), new ItemStack(Material.BRAIN_CORAL, 3));
-        registerRecipe(20, new ItemStack(Material.DEAD_BUBBLE_CORAL), new ItemStack(Material.BUBBLE_CORAL, 3));
-        registerRecipe(20, new ItemStack(Material.DEAD_FIRE_CORAL), new ItemStack(Material.FIRE_CORAL, 3));
-        registerRecipe(20, new ItemStack(Material.DEAD_HORN_CORAL), new ItemStack(Material.HORN_CORAL, 3));
+        registerRecipe(9, new ItemStack(Material.DEAD_TUBE_CORAL), new ItemStack(Material.TUBE_CORAL, 3));
+        registerRecipe(9, new ItemStack(Material.DEAD_BRAIN_CORAL), new ItemStack(Material.BRAIN_CORAL, 3));
+        registerRecipe(9, new ItemStack(Material.DEAD_BUBBLE_CORAL), new ItemStack(Material.BUBBLE_CORAL, 3));
+        registerRecipe(9, new ItemStack(Material.DEAD_FIRE_CORAL), new ItemStack(Material.FIRE_CORAL, 3));
+        registerRecipe(9, new ItemStack(Material.DEAD_HORN_CORAL), new ItemStack(Material.HORN_CORAL, 3));
         // Coral duplication
-        registerRecipe(20, new ItemStack(Material.TUBE_CORAL), new ItemStack(Material.TUBE_CORAL, 6));
-        registerRecipe(20, new ItemStack(Material.BRAIN_CORAL), new ItemStack(Material.BRAIN_CORAL, 6));
-        registerRecipe(20, new ItemStack(Material.BUBBLE_CORAL), new ItemStack(Material.BUBBLE_CORAL, 6));
-        registerRecipe(20, new ItemStack(Material.FIRE_CORAL), new ItemStack(Material.FIRE_CORAL, 6));
-        registerRecipe(20, new ItemStack(Material.HORN_CORAL), new ItemStack(Material.HORN_CORAL, 6));
+        registerRecipe(12, new ItemStack(Material.TUBE_CORAL), new ItemStack(Material.TUBE_CORAL, 6));
+        registerRecipe(12, new ItemStack(Material.BRAIN_CORAL), new ItemStack(Material.BRAIN_CORAL, 6));
+        registerRecipe(12, new ItemStack(Material.BUBBLE_CORAL), new ItemStack(Material.BUBBLE_CORAL, 6));
+        registerRecipe(12, new ItemStack(Material.FIRE_CORAL), new ItemStack(Material.FIRE_CORAL, 6));
+        registerRecipe(12, new ItemStack(Material.HORN_CORAL), new ItemStack(Material.HORN_CORAL, 6));
 
     // Coral fans
         // Medical attention for the fans
-        registerRecipe(20, new ItemStack(Material.DEAD_TUBE_CORAL_FAN), new ItemStack(Material.TUBE_CORAL_FAN, 3));
-        registerRecipe(20, new ItemStack(Material.DEAD_BRAIN_CORAL_FAN), new ItemStack(Material.BRAIN_CORAL_FAN, 3));
-        registerRecipe(20, new ItemStack(Material.DEAD_BUBBLE_CORAL_FAN), new ItemStack(Material.BUBBLE_CORAL_FAN, 3));
-        registerRecipe(20, new ItemStack(Material.DEAD_FIRE_CORAL_FAN), new ItemStack(Material.FIRE_CORAL_FAN, 3));
-        registerRecipe(20, new ItemStack(Material.DEAD_HORN_CORAL_FAN), new ItemStack(Material.HORN_CORAL_FAN, 3));
+        registerRecipe(9, new ItemStack(Material.DEAD_TUBE_CORAL_FAN), new ItemStack(Material.TUBE_CORAL_FAN, 3));
+        registerRecipe(9, new ItemStack(Material.DEAD_BRAIN_CORAL_FAN), new ItemStack(Material.BRAIN_CORAL_FAN, 3));
+        registerRecipe(9, new ItemStack(Material.DEAD_BUBBLE_CORAL_FAN), new ItemStack(Material.BUBBLE_CORAL_FAN, 3));
+        registerRecipe(9, new ItemStack(Material.DEAD_FIRE_CORAL_FAN), new ItemStack(Material.FIRE_CORAL_FAN, 3));
+        registerRecipe(9, new ItemStack(Material.DEAD_HORN_CORAL_FAN), new ItemStack(Material.HORN_CORAL_FAN, 3));
         // Fan duplication
-        registerRecipe(20, new ItemStack(Material.TUBE_CORAL_FAN), new ItemStack(Material.TUBE_CORAL_FAN, 6));
-        registerRecipe(20, new ItemStack(Material.BRAIN_CORAL_FAN), new ItemStack(Material.BRAIN_CORAL_FAN, 6));
-        registerRecipe(20, new ItemStack(Material.BUBBLE_CORAL_FAN), new ItemStack(Material.BUBBLE_CORAL_FAN, 6));
-        registerRecipe(20, new ItemStack(Material.FIRE_CORAL_FAN), new ItemStack(Material.FIRE_CORAL_FAN, 6));
-        registerRecipe(20, new ItemStack(Material.HORN_CORAL_FAN), new ItemStack(Material.HORN_CORAL_FAN, 6));
+        registerRecipe(12, new ItemStack(Material.TUBE_CORAL_FAN), new ItemStack(Material.TUBE_CORAL_FAN, 6));
+        registerRecipe(12, new ItemStack(Material.BRAIN_CORAL_FAN), new ItemStack(Material.BRAIN_CORAL_FAN, 6));
+        registerRecipe(12, new ItemStack(Material.BUBBLE_CORAL_FAN), new ItemStack(Material.BUBBLE_CORAL_FAN, 6));
+        registerRecipe(12, new ItemStack(Material.FIRE_CORAL_FAN), new ItemStack(Material.FIRE_CORAL_FAN, 6));
+        registerRecipe(12, new ItemStack(Material.HORN_CORAL_FAN), new ItemStack(Material.HORN_CORAL_FAN, 6));
 
     }
 

--- a/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberOceanMK2.java
+++ b/src/main/java/me/profelements/dynatech/items/electric/GrowthChamberOceanMK2.java
@@ -1,0 +1,120 @@
+package me.profelements.dynatech.items.electric;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import me.mrCookieSlime.Slimefun.Lists.RecipeType;
+import me.mrCookieSlime.Slimefun.Objects.Category;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.abstractItems.MachineRecipe;
+import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
+import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
+import me.profelements.dynatech.DynaTech;
+import me.profelements.dynatech.items.electric.abstracts.AMachine;
+
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
+
+public class GrowthChamberOceanMK2 extends AMachine {
+    
+    private static int[] BORDER = new int[] {};
+    private static int[] BORDER_IN = new int[] {0,8,9,10,11,12,14,15,16,17};
+    private static int[] BORDER_OUT = new int[] {18,19,20,21,22,23,24,25,26,27,35,36,44,45,53};
+    
+    public GrowthChamberOceanMK2(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+        super(category, item, recipeType, recipe);
+
+    }
+
+    @Override
+    protected void registerDefaultRecipes() {
+
+        registerRecipe(20, new ItemStack(Material.LILY_PAD), new ItemStack(Material.LILY_PAD, 9));
+        registerRecipe(20, new ItemStack(Material.SEA_PICKLE), new ItemStack(Material.SEA_PICKLE, 9));
+        registerRecipe(20, new ItemStack(Material.SEAGRASS), new ItemStack(Material.SEAGRASS, 12));
+        registerRecipe(0, new ItemStack(Material.KELP), new ItemStack(Material.KELP, 9));
+    // Coral blocks
+        // Brings dead coral blocks back to life!
+        registerRecipe(20, new ItemStack(Material.DEAD_TUBE_CORAL_BLOCK), new ItemStack(Material.TUBE_CORAL_BLOCK, 3));
+        registerRecipe(20, new ItemStack(Material.DEAD_BRAIN_CORAL_BLOCK), new ItemStack(Material.BRAIN_CORAL_BLOCK, 3));
+        registerRecipe(20, new ItemStack(Material.DEAD_BUBBLE_CORAL_BLOCK), new ItemStack(Material.BUBBLE_CORAL_BLOCK, 3));
+        registerRecipe(20, new ItemStack(Material.DEAD_FIRE_CORAL_BLOCK), new ItemStack(Material.FIRE_CORAL_BLOCK, 3));
+        registerRecipe(20, new ItemStack(Material.DEAD_HORN_CORAL_BLOCK), new ItemStack(Material.HORN_CORAL_BLOCK, 3));
+        // Block duplication
+        registerRecipe(20, new ItemStack(Material.TUBE_CORAL_BLOCK), new ItemStack(Material.TUBE_CORAL_BLOCK, 6));
+        registerRecipe(20, new ItemStack(Material.BRAIN_CORAL_BLOCK), new ItemStack(Material.BRAIN_CORAL_BLOCK, 6));
+        registerRecipe(20, new ItemStack(Material.BUBBLE_CORAL_BLOCK), new ItemStack(Material.BUBBLE_CORAL_BLOCK, 6));
+        registerRecipe(20, new ItemStack(Material.FIRE_CORAL_BLOCK), new ItemStack(Material.FIRE_CORAL_BLOCK, 6));
+        registerRecipe(20, new ItemStack(Material.HORN_CORAL_BLOCK), new ItemStack(Material.HORN_CORAL_BLOCK, 6));
+
+    // Coral
+        // Revive for coral
+        registerRecipe(20, new ItemStack(Material.DEAD_TUBE_CORAL), new ItemStack(Material.TUBE_CORAL, 3));
+        registerRecipe(20, new ItemStack(Material.DEAD_BRAIN_CORAL), new ItemStack(Material.BRAIN_CORAL, 3));
+        registerRecipe(20, new ItemStack(Material.DEAD_BUBBLE_CORAL), new ItemStack(Material.BUBBLE_CORAL, 3));
+        registerRecipe(20, new ItemStack(Material.DEAD_FIRE_CORAL), new ItemStack(Material.FIRE_CORAL, 3));
+        registerRecipe(20, new ItemStack(Material.DEAD_HORN_CORAL), new ItemStack(Material.HORN_CORAL, 3));
+        // Coral duplication
+        registerRecipe(20, new ItemStack(Material.TUBE_CORAL), new ItemStack(Material.TUBE_CORAL, 6));
+        registerRecipe(20, new ItemStack(Material.BRAIN_CORAL), new ItemStack(Material.BRAIN_CORAL, 6));
+        registerRecipe(20, new ItemStack(Material.BUBBLE_CORAL), new ItemStack(Material.BUBBLE_CORAL, 6));
+        registerRecipe(20, new ItemStack(Material.FIRE_CORAL), new ItemStack(Material.FIRE_CORAL, 6));
+        registerRecipe(20, new ItemStack(Material.HORN_CORAL), new ItemStack(Material.HORN_CORAL, 6));
+
+    // Coral fans
+        // Medical attention for the fans
+        registerRecipe(20, new ItemStack(Material.DEAD_TUBE_CORAL_FAN), new ItemStack(Material.TUBE_CORAL_FAN, 3));
+        registerRecipe(20, new ItemStack(Material.DEAD_BRAIN_CORAL_FAN), new ItemStack(Material.BRAIN_CORAL_FAN, 3));
+        registerRecipe(20, new ItemStack(Material.DEAD_BUBBLE_CORAL_FAN), new ItemStack(Material.BUBBLE_CORAL_FAN, 3));
+        registerRecipe(20, new ItemStack(Material.DEAD_FIRE_CORAL_FAN), new ItemStack(Material.FIRE_CORAL_FAN, 3));
+        registerRecipe(20, new ItemStack(Material.DEAD_HORN_CORAL_FAN), new ItemStack(Material.HORN_CORAL_FAN, 3));
+        // Fan duplication
+        registerRecipe(20, new ItemStack(Material.TUBE_CORAL_FAN), new ItemStack(Material.TUBE_CORAL_FAN, 6));
+        registerRecipe(20, new ItemStack(Material.BRAIN_CORAL_FAN), new ItemStack(Material.BRAIN_CORAL_FAN, 6));
+        registerRecipe(20, new ItemStack(Material.BUBBLE_CORAL_FAN), new ItemStack(Material.BUBBLE_CORAL_FAN, 6));
+        registerRecipe(20, new ItemStack(Material.FIRE_CORAL_FAN), new ItemStack(Material.FIRE_CORAL_FAN, 6));
+        registerRecipe(20, new ItemStack(Material.HORN_CORAL_FAN), new ItemStack(Material.HORN_CORAL_FAN, 6));
+
+    }
+
+    @Override
+    public boolean isGraphical() {
+        return true;
+    }
+    
+    @Override
+    public String getMachineIdentifier() {
+        return "GROWTH_CHAMBER_OCEAN_MK2";
+    }
+
+
+    @Override
+    public List<int[]> getBorders() {
+        List<int[]> borders = new ArrayList<>();
+        borders.add(BORDER);
+        borders.add(BORDER_IN);
+        borders.add(BORDER_OUT);
+        
+        return borders;
+    }
+    
+    @Override
+    public int[] getInputSlots() {
+        return new int[] {1,2,3,4,5,6,7};
+    }
+    @Override
+    public int[] getOutputSlots() {
+        return new int[] {28,29,30,31,32,33,34,37,38,39,40,41,42,43,46,47,48,49,50,51,52};
+    }
+
+    @Override
+    public ItemStack getProgressBar() {
+        return new ItemStack(Material.CONDUIT);
+    }
+    
+    @Override
+    public int getProgressBarSlot() {
+        return 13;
+    }
+    
+}

--- a/src/main/java/me/profelements/dynatech/setup/DynaTechItemsSetup.java
+++ b/src/main/java/me/profelements/dynatech/setup/DynaTechItemsSetup.java
@@ -15,6 +15,12 @@ import me.profelements.dynatech.items.electric.BandaidManager;
 import me.profelements.dynatech.items.electric.BarbedWire;
 import me.profelements.dynatech.items.electric.GrowthChamber;
 import me.profelements.dynatech.items.electric.GrowthChamberMK2;
+import me.profelements.dynatech.items.electric.GrowthChamberEnd;
+import me.profelements.dynatech.items.electric.GrowthChamberEndMK2;
+import me.profelements.dynatech.items.electric.GrowthChamberNether;
+import me.profelements.dynatech.items.electric.GrowthChamberNetherMK2;
+import me.profelements.dynatech.items.electric.GrowthChamberOcean;
+import me.profelements.dynatech.items.electric.GrowthChamberOceanMK2;
 import me.profelements.dynatech.items.electric.MaterialHive;
 import me.profelements.dynatech.items.electric.PotionSprinkler;
 import me.profelements.dynatech.items.electric.SeedPlucker;
@@ -206,7 +212,6 @@ public class DynaTechItemsSetup {
                         .register(plugin);
         }
        
-
         new GrowthChamber(DynaTechItems.DynaTechGeneral, DynaTechItems.GROWTH_CHAMBER, RecipeType.ENHANCED_CRAFTING_TABLE,
                 new ItemStack[] {
                         SlimefunItems.HARDENED_GLASS,SlimefunItems.TREE_GROWTH_ACCELERATOR,SlimefunItems.HARDENED_GLASS,
@@ -222,13 +227,85 @@ public class DynaTechItemsSetup {
         new GrowthChamberMK2(DynaTechItems.DynaTechGeneral, DynaTechItems.GROWTH_CHAMBER_MK2, RecipeType.ENHANCED_CRAFTING_TABLE,
                 new ItemStack[] {
                         SlimefunItems.STEEL_PLATE,DynaTechItems.GROWTH_CHAMBER,SlimefunItems.STEEL_PLATE,
-                        new ItemStack(Material.WATER_BUCKET),new ItemStack(Material.LIME_STAINED_GLASS),new ItemStack(Material.NETHERRACK),
+                        new ItemStack(Material.GRASS_BLOCK,new ItemStack(Material.LIME_STAINED_GLASS),new ItemStack(Material.SAND),
                         SlimefunItems.STEEL_PLATE,DynaTechItems.GROWTH_CHAMBER,SlimefunItems.STEEL_PLATE
 
                 })
+                .setEnergyCapacity(1024)
+                .setEnergyConsumption(128)
+                .setProcessingSpeed(3)
+                .register(plugin);
+
+        new GrowthChamberEnd(DynaTechItems.DynaTechGeneral, DynaTechItems.GROWTH_CHAMBER_END, RecipeType.ENHANCED_CRAFTING_TABLE,
+                new ItemStack[] {
+                        SlimefunItems.HARDENED_GLASS,new ItemStack(Material.MAGENTA_STAINED_GLASS),SlimefunItems.HARDENED_GLASS,
+                        new ItemStack(Material.PURPUR_BLOCK),new ItemStack(Material.CHORUS_FLOWER),new ItemStack(Material.END_STONE),
+                        DynaTechItems.STAINLESS_STEEL,DynaTechItems.GROWTH_CHAMBER,DynaTechItems.STAINLESS_STEEL
+
+                })
                 .setEnergyCapacity(512)
-                .setEnergyConsumption(80)
-                .setProcessingSpeed(4)
+                .setEnergyConsumption(32)
+                .setProcessingSpeed(1)
+                .register(plugin);
+
+        new GrowthChamberEndMK2(DynaTechItems.DynaTechGeneral, DynaTechItems.GROWTH_CHAMBER_END_MK2, RecipeType.ENHANCED_CRAFTING_TABLE,
+                new ItemStack[] {
+                        SlimefunItems.STEEL_PLATE,DynaTechItems.GROWTH_CHAMBER_END,SlimefunItems.STEEL_PLATE,
+                        new ItemStack(Material.PURPUR_PILLAR),new ItemStack(Material.PURPLE_STAINED_GLASS),new ItemStack(Material.END_STONE_BRICKS),
+                        SlimefunItems.STEEL_PLATE,DynaTechItems.GROWTH_CHAMBER_END,SlimefunItems.STEEL_PLATE
+
+                })
+                .setEnergyCapacity(1024)
+                .setEnergyConsumption(128)
+                .setProcessingSpeed(3)
+                .register(plugin);
+
+        new GrowthChamberNether(DynaTechItems.DynaTechGeneral, DynaTechItems.GROWTH_CHAMBER_NETHER, RecipeType.ENHANCED_CRAFTING_TABLE,
+                new ItemStack[] {
+                        SlimefunItems.HARDENED_GLASS,new ItemStack(Material.RED_STAINED_GLASS),SlimefunItems.HARDENED_GLASS,
+                        new ItemStack(Material.CRIMSON_NYLIUM),new ItemStack(Material.SOUL_SAND),new ItemStack(Material.WARPED_NYLIUM),
+                        DynaTechItems.STAINLESS_STEEL,DynaTechItems.GROWTH_CHAMBER,DynaTechItems.STAINLESS_STEEL
+
+                })
+                .setEnergyCapacity(512)
+                .setEnergyConsumption(32)
+                .setProcessingSpeed(1)
+                .register(plugin);
+
+        new GrowthChamberNetherMK2(DynaTechItems.DynaTechGeneral, DynaTechItems.GROWTH_CHAMBER_NETHER_MK2, RecipeType.ENHANCED_CRAFTING_TABLE,
+                new ItemStack[] {
+                        SlimefunItems.STEEL_PLATE,DynaTechItems.GROWTH_CHAMBER_NETHER,SlimefunItems.STEEL_PLATE,
+                        new ItemStack(Material.CRIMSON_NYLIUM,new ItemStack(Material.SOUL_SAND),new ItemStack(Material.WARPED_NYLIUM),
+                        SlimefunItems.STEEL_PLATE,DynaTechItems.GROWTH_CHAMBER_NETHER,SlimefunItems.STEEL_PLATE
+
+                })
+                .setEnergyCapacity(1024)
+                .setEnergyConsumption(128)
+                .setProcessingSpeed(3)
+                .register(plugin);
+
+        new GrowthChamberOcean(DynaTechItems.DynaTechGeneral, DynaTechItems.GROWTH_CHAMBER_OCEAN, RecipeType.ENHANCED_CRAFTING_TABLE,
+                new ItemStack[] {
+                        SlimefunItems.HARDENED_GLASS,new ItemStack(Material.CYAN_STAINED_GLASS),SlimefunItems.HARDENED_GLASS,
+                        new ItemStack(Material.WATER_BUCKET),new ItemStack(Material.SAND),new ItemStack(Material.WATER_BUCKET),
+                        DynaTechItems.STAINLESS_STEEL,DynaTechItems.GROWTH_CHAMBER,DynaTechItems.STAINLESS_STEEL
+
+                })
+                .setEnergyCapacity(512)
+                .setEnergyConsumption(32)
+                .setProcessingSpeed(1)
+                .register(plugin);
+
+        new GrowthChamberOceanMK2(DynaTechItems.DynaTechGeneral, DynaTechItems.GROWTH_CHAMBER_OCEAN_MK2, RecipeType.ENHANCED_CRAFTING_TABLE,
+                new ItemStack[] {
+                        SlimefunItems.STEEL_PLATE,DynaTechItems.GROWTH_CHAMBER_OCEAN,SlimefunItems.STEEL_PLATE,
+                        new ItemStack(Material.GRAVEL,new ItemStack(Material.LIGHT_BLUE_STAINED_GLASS),new ItemStack(Material.DIRT),
+                        SlimefunItems.STEEL_PLATE,DynaTechItems.GROWTH_CHAMBER_OCEAN,SlimefunItems.STEEL_PLATE
+
+                })
+                .setEnergyCapacity(512)
+                .setEnergyConsumption(128)
+                .setProcessingSpeed(3)
                 .register(plugin);
 
         new AntigravityBubble(DynaTechItems.DynaTechGeneral, DynaTechItems.ANTIGRAVITY_BUBBLE, RecipeType.ENHANCED_CRAFTING_TABLE,

--- a/src/main/java/me/profelements/dynatech/setup/DynaTechItemsSetup.java
+++ b/src/main/java/me/profelements/dynatech/setup/DynaTechItemsSetup.java
@@ -227,7 +227,7 @@ public class DynaTechItemsSetup {
         new GrowthChamberMK2(DynaTechItems.DynaTechGeneral, DynaTechItems.GROWTH_CHAMBER_MK2, RecipeType.ENHANCED_CRAFTING_TABLE,
                 new ItemStack[] {
                         SlimefunItems.STEEL_PLATE,DynaTechItems.GROWTH_CHAMBER,SlimefunItems.STEEL_PLATE,
-                        new ItemStack(Material.GRASS_BLOCK,new ItemStack(Material.LIME_STAINED_GLASS),new ItemStack(Material.SAND),
+                        new ItemStack(Material.GRASS_BLOCK),new ItemStack(Material.LIME_STAINED_GLASS),new ItemStack(Material.SAND),
                         SlimefunItems.STEEL_PLATE,DynaTechItems.GROWTH_CHAMBER,SlimefunItems.STEEL_PLATE
 
                 })
@@ -275,7 +275,7 @@ public class DynaTechItemsSetup {
         new GrowthChamberNetherMK2(DynaTechItems.DynaTechGeneral, DynaTechItems.GROWTH_CHAMBER_NETHER_MK2, RecipeType.ENHANCED_CRAFTING_TABLE,
                 new ItemStack[] {
                         SlimefunItems.STEEL_PLATE,DynaTechItems.GROWTH_CHAMBER_NETHER,SlimefunItems.STEEL_PLATE,
-                        new ItemStack(Material.CRIMSON_NYLIUM,new ItemStack(Material.SOUL_SAND),new ItemStack(Material.WARPED_NYLIUM),
+                        new ItemStack(Material.CRIMSON_NYLIUM),new ItemStack(Material.SOUL_SAND),new ItemStack(Material.WARPED_NYLIUM),
                         SlimefunItems.STEEL_PLATE,DynaTechItems.GROWTH_CHAMBER_NETHER,SlimefunItems.STEEL_PLATE
 
                 })
@@ -299,7 +299,7 @@ public class DynaTechItemsSetup {
         new GrowthChamberOceanMK2(DynaTechItems.DynaTechGeneral, DynaTechItems.GROWTH_CHAMBER_OCEAN_MK2, RecipeType.ENHANCED_CRAFTING_TABLE,
                 new ItemStack[] {
                         SlimefunItems.STEEL_PLATE,DynaTechItems.GROWTH_CHAMBER_OCEAN,SlimefunItems.STEEL_PLATE,
-                        new ItemStack(Material.GRAVEL,new ItemStack(Material.LIGHT_BLUE_STAINED_GLASS),new ItemStack(Material.DIRT),
+                        new ItemStack(Material.GRAVEL),new ItemStack(Material.LIGHT_BLUE_STAINED_GLASS),new ItemStack(Material.DIRT),
                         SlimefunItems.STEEL_PLATE,DynaTechItems.GROWTH_CHAMBER_OCEAN,SlimefunItems.STEEL_PLATE
 
                 })

--- a/src/main/java/me/profelements/dynatech/setup/DynaTechItemsSetup.java
+++ b/src/main/java/me/profelements/dynatech/setup/DynaTechItemsSetup.java
@@ -303,7 +303,7 @@ public class DynaTechItemsSetup {
                         SlimefunItems.STEEL_PLATE,DynaTechItems.GROWTH_CHAMBER_OCEAN,SlimefunItems.STEEL_PLATE
 
                 })
-                .setEnergyCapacity(512)
+                .setEnergyCapacity(1024)
                 .setEnergyConsumption(128)
                 .setProcessingSpeed(3)
                 .register(plugin);


### PR DESCRIPTION
Adds the End, Nether and Ocean growth chambers as well as their MK2 version
Moves recipes from the growth chamber to the now respective machine and adds some more recipes, namely coral and flowers.
Increased power consumption to 128 in MK2's and power buffer to 1024.
Changed speed to 3x.
Changed recipes' processing time.