### PR TITLE
Massively optimise hydro and dragon egg gens

### DIFF
--- a/src/main/java/me/profelements/dynatech/DynaTech.java
+++ b/src/main/java/me/profelements/dynatech/DynaTech.java
@@ -1,17 +1,8 @@
 package me.profelements.dynatech;
 
-import org.apache.commons.lang.Validate;
-import org.bstats.bukkit.Metrics;
-import org.bukkit.Bukkit;
-import org.bukkit.World;
-import org.bukkit.WorldCreator;
-import org.bukkit.plugin.java.JavaPlugin;
-import org.bukkit.scheduler.BukkitTask;
-
 import io.github.thebusybiscuit.slimefun4.api.SlimefunAddon;
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunPlugin;
 import me.mrCookieSlime.Slimefun.api.BlockStorage;
-import me.mrCookieSlime.Slimefun.cscorelib2.config.Config;
 import me.mrCookieSlime.Slimefun.cscorelib2.updater.GitHubBuildsUpdater;
 import me.profelements.dynatech.items.backpacks.PicnicBasket;
 import me.profelements.dynatech.items.misc.DimensionalHomeDimension;
@@ -22,11 +13,17 @@ import me.profelements.dynatech.listeners.InventoryFilterListener;
 import me.profelements.dynatech.listeners.PicnicBasketListener;
 import me.profelements.dynatech.setup.DynaTechItemsSetup;
 import me.profelements.dynatech.tasks.ItemBandTask;
-
-import java.util.logging.Level;
+import org.apache.commons.lang.Validate;
+import org.bstats.bukkit.Metrics;
+import org.bukkit.Bukkit;
+import org.bukkit.World;
+import org.bukkit.WorldCreator;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.scheduler.BukkitTask;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import java.util.logging.Level;
 
 public class DynaTech extends JavaPlugin implements SlimefunAddon {
 
@@ -44,12 +41,10 @@ public class DynaTech extends JavaPlugin implements SlimefunAddon {
         infinityExpansionInstalled = Bukkit.getServer().getPluginManager().isPluginEnabled("InfinityExpansion");
 
         saveDefaultConfig();
-        
-        Config cfg = new Config(this);
-        
+
         new Metrics(this, 9689);
 
-        if (!cfg.getBoolean("options.disable-dimensionalhome-world")) {
+        if (!getConfig().getBoolean("options.disable-dimensionalhome-world")) {
             WorldCreator worldCreator = new WorldCreator("dimensionalhome");
             worldCreator.generator(new DimensionalHomeDimension());
             World dimensionalHome = worldCreator.createWorld();
@@ -65,7 +60,7 @@ public class DynaTech extends JavaPlugin implements SlimefunAddon {
         getServer().getScheduler().runTaskTimerAsynchronously(DynaTech.getInstance(), new ItemBandTask(), 0L, 5 * 20L);
         getServer().getScheduler().runTaskTimer(DynaTech.getInstance(), () -> this.tickInterval++, 0, TICK_TIME);
 
-        if (cfg.getBoolean("options.auto-update", true) && getDescription().getVersion().startsWith("DEV - ")) {
+        if (getConfig().getBoolean("options.auto-update", true) && getDescription().getVersion().startsWith("DEV - ")) {
             new GitHubBuildsUpdater(this, getFile(), "ProfElements/DynaTech/master");
         }
 
@@ -120,5 +115,5 @@ public class DynaTech extends JavaPlugin implements SlimefunAddon {
 
         return instance.getServer().getScheduler().runTask(getInstance(), runnable);
     }
-    
+
 }

--- a/src/main/java/me/profelements/dynatech/DynaTech.java
+++ b/src/main/java/me/profelements/dynatech/DynaTech.java
@@ -65,7 +65,7 @@ public class DynaTech extends JavaPlugin implements SlimefunAddon {
         getServer().getScheduler().runTaskTimerAsynchronously(DynaTech.getInstance(), new ItemBandTask(), 0L, 5 * 20L);
         getServer().getScheduler().runTaskTimer(DynaTech.getInstance(), () -> this.tickInterval++, 0, TICK_TIME);
 
-        if (cfg.getBoolean("options.auto-updates") && getDescription().getVersion().startsWith("DEV - ")) {
+        if (cfg.getBoolean("options.auto-update", true) && getDescription().getVersion().startsWith("DEV - ")) {
             new GitHubBuildsUpdater(this, getFile(), "ProfElements/DynaTech/master");
         }
 

--- a/src/main/java/me/profelements/dynatech/DynaTech.java
+++ b/src/main/java/me/profelements/dynatech/DynaTech.java
@@ -35,7 +35,7 @@ public class DynaTech extends JavaPlugin implements SlimefunAddon {
     private static boolean infinityExpansionInstalled;
 
     private int tickInterval;
-    
+
     @Override
     public void onEnable() {
         instance = this;
@@ -47,7 +47,7 @@ public class DynaTech extends JavaPlugin implements SlimefunAddon {
         
         Config cfg = new Config(this);
         
-        final Metrics metrics = new Metrics(this, 9689);
+        new Metrics(this, 9689);
 
         if (!cfg.getBoolean("options.disable-dimensionalhome-world")) {
             WorldCreator worldCreator = new WorldCreator("dimensionalhome");
@@ -98,10 +98,8 @@ public class DynaTech extends JavaPlugin implements SlimefunAddon {
         return instance;
     }
 
-    @Nonnull
     public int getTickInterval() {
         return tickInterval;
-
     }
 
     public static boolean isExoticGardenInstalled() {

--- a/src/main/java/me/profelements/dynatech/items/electric/WeatherController.java
+++ b/src/main/java/me/profelements/dynatech/items/electric/WeatherController.java
@@ -17,7 +17,6 @@ import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
 import me.mrCookieSlime.Slimefun.cscorelib2.item.CustomItem;
-import me.profelements.dynatech.DynaTech;
 import me.profelements.dynatech.items.electric.abstracts.AMachine;
 
 import javax.annotation.Nonnull;
@@ -42,7 +41,7 @@ public class WeatherController extends AMachine implements RecipeDisplayItem {
         BlockMenu menu = BlockStorage.getInventory(b);
         ItemStack item = menu.getItemInSlot(getInputSlots()[0]);
 
-        if( item != null && (item.getType() == Material.SUNFLOWER || item.getType() == Material.LILAC || item.getType() == Material.CREEPER_HEAD) ) {
+        if (item != null && (item.getType() == Material.SUNFLOWER || item.getType() == Material.LILAC || item.getType() == Material.CREEPER_HEAD)) {
             if (item.getType() == Material.SUNFLOWER) {
                 if (b.getWorld().isClearWeather()) {
                     return;
@@ -52,10 +51,10 @@ public class WeatherController extends AMachine implements RecipeDisplayItem {
             }
             
             if (item.getType() == Material.LILAC) {
-                if(b.getWorld().hasStorm()) {
+                if (b.getWorld().hasStorm()) {
                     return;
                 }
-                DynaTech.runSync(()->b.getWorld().setStorm(true));
+                b.getWorld().setStorm(true);
                 b.getWorld().setWeatherDuration(1200);
                 removeCharge(b.getLocation(), getEnergyConsumption());
             }
@@ -64,7 +63,7 @@ public class WeatherController extends AMachine implements RecipeDisplayItem {
                 if (b.getWorld().isThundering()) {
                     return;
                 }
-                DynaTech.runSync(()->b.getWorld().setThundering(true));
+                b.getWorld().setThundering(true);
                 b.getWorld().setThunderDuration(1200);
                 removeCharge(b.getLocation(), getEnergyConsumption());
             }
@@ -76,8 +75,8 @@ public class WeatherController extends AMachine implements RecipeDisplayItem {
         return new BlockBreakHandler(false, false) {
             @Override
             public void onPlayerBreak(BlockBreakEvent event, ItemStack item, List<ItemStack> drops) {
-              DynaTech.runSync(()->event.getBlock().getWorld().setClearWeatherDuration(60));
-            }   
+                event.getBlock().getWorld().setClearWeatherDuration(60);
+            }
         };
     }
 

--- a/src/main/java/me/profelements/dynatech/items/electric/generators/CulinaryGenerator.java
+++ b/src/main/java/me/profelements/dynatech/items/electric/generators/CulinaryGenerator.java
@@ -1,10 +1,5 @@
 package me.profelements.dynatech.items.electric.generators;
 
-import java.util.Map;
-
-import org.bukkit.Material;
-import org.bukkit.inventory.ItemStack;
-
 import io.github.thebusybiscuit.exoticgarden.items.CustomFood;
 import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
 import io.github.thebusybiscuit.slimefun4.core.attributes.NotHopperable;
@@ -16,12 +11,15 @@ import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
 import me.mrCookieSlime.Slimefun.api.inventory.BlockMenu;
 import me.profelements.dynatech.DynaTech;
 import me.profelements.dynatech.items.electric.abstracts.AMachineGenerator;
+import org.bukkit.Material;
+import org.bukkit.inventory.ItemStack;
 
 import javax.annotation.Nonnull;
+import java.util.Map;
 
 public class CulinaryGenerator extends AMachineGenerator implements NotHopperable {
 
-    private ItemSetting<Boolean> exoticGardenIntegration = new ItemSetting<Boolean>(this, "exotic-garden-integration", true);
+    private ItemSetting<Boolean> exoticGardenIntegration = new ItemSetting<>(this, "exotic-garden-integration", true);
 
     public CulinaryGenerator(Category category, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
         super(category, item, recipeType, recipe);
@@ -29,10 +27,8 @@ public class CulinaryGenerator extends AMachineGenerator implements NotHopperabl
         addItemSetting(exoticGardenIntegration);
     }
 
-
     @Override
     public void registerDefaultFuelTypes() {
-       
         //1 Food Levels
         registerFuel(new MachineFuel(2, new ItemStack(Material.BEETROOT)));
         registerFuel(new MachineFuel(2, new ItemStack(Material.DRIED_KELP)));
@@ -71,7 +67,7 @@ public class CulinaryGenerator extends AMachineGenerator implements NotHopperabl
         registerFuel(new MachineFuel(24, new ItemStack(Material.COOKED_CHICKEN)));
         registerFuel(new MachineFuel(24, new ItemStack(Material.COOKED_SALMON)));
         registerFuel(new MachineFuel(24, new ItemStack(Material.GOLDEN_CARROT)));
-        
+
         //8 Food Levels
         registerFuel(new MachineFuel(36, new ItemStack(Material.COOKED_PORKCHOP)));
         registerFuel(new MachineFuel(36, new ItemStack(Material.COOKED_BEEF)));
@@ -85,19 +81,18 @@ public class CulinaryGenerator extends AMachineGenerator implements NotHopperabl
                 SlimefunItem sfItem = SlimefunItem.getByItem(inv.getItemInSlot(inputSlot));
                 if (sfItem instanceof CustomFood) {
                     CustomFood cfItem = (CustomFood) sfItem;
-                    MachineFuel fuel = new MachineFuel(cfItem.getFoodValue()*4, sfItem.getItem());    
-                    inv.consumeItem(inputSlot);                
+                    MachineFuel fuel = new MachineFuel(cfItem.getFoodValue() * 4, sfItem.getItem());
+                    inv.consumeItem(inputSlot);
                     return fuel;
                 }
             }
         }
-        return super.findRecipe(inv, found); 
-    }    
-             
+        return super.findRecipe(inv, found);
+    }
 
     @Override
     public String getMachineIdentifier() {
-       return "CULINARY_GENERATOR";
+        return "CULINARY_GENERATOR";
     }
 
     @Nonnull
@@ -105,5 +100,4 @@ public class CulinaryGenerator extends AMachineGenerator implements NotHopperabl
     public ItemStack getProgressBar() {
         return new ItemStack(Material.IRON_SHOVEL);
     }
-    
 }

--- a/src/main/java/me/profelements/dynatech/items/electric/generators/DragonEggGenerator.java
+++ b/src/main/java/me/profelements/dynatech/items/electric/generators/DragonEggGenerator.java
@@ -1,20 +1,16 @@
 package me.profelements.dynatech.items.electric.generators;
 
+import io.github.thebusybiscuit.slimefun4.core.attributes.EnergyNetProvider;
 import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.Category;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
-import me.mrCookieSlime.Slimefun.api.BlockStorage;
 import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
-import me.profelements.dynatech.DynaTech;
-
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.inventory.ItemStack;
-
-import io.github.thebusybiscuit.slimefun4.core.attributes.EnergyNetProvider;
 
 import javax.annotation.Nonnull;
 
@@ -26,29 +22,17 @@ public class DragonEggGenerator extends SlimefunItem implements EnergyNetProvide
 
     @Override
     public int getGeneratedOutput(@Nonnull Location location, @Nonnull Config config) {
-        if (DynaTech.getInstance().getTickInterval()  % 10 == 0) {
-            
-            Block dragonEgg = location.getBlock().getRelative(BlockFace.UP);
-            if (dragonEgg.getType() == Material.DRAGON_EGG) {
-                BlockStorage.addBlockInfo(location, "egg", String.valueOf(true));
-                return getEnergyProduction();
-            } else {
-                BlockStorage.addBlockInfo(location, "egg", String.valueOf(false));
-            }
-
-         } else if (BlockStorage.getLocationInfo(location, "egg") != null && BlockStorage.getLocationInfo(location, "egg").equals(String.valueOf(true))){
-            return getEnergyProduction();
+        Block dragonEgg = location.getBlock().getRelative(BlockFace.UP);
+        if (dragonEgg.getType() == Material.DRAGON_EGG) {
+            return 32;
         }
-        return 0; 
+
+        return 0;
     }
 
     @Override
     public boolean isChargeable() {
         return false;
-    }
-
-    public static final int getEnergyProduction() {
-        return 32;
     }
 
     @Override

--- a/src/main/java/me/profelements/dynatech/items/electric/generators/HydroGenerator.java
+++ b/src/main/java/me/profelements/dynatech/items/electric/generators/HydroGenerator.java
@@ -1,59 +1,80 @@
-package me.profelements.dynatech.items.electric.generators;
-
-import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
-import me.mrCookieSlime.Slimefun.Lists.RecipeType;
-import me.mrCookieSlime.Slimefun.Objects.Category;
-import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
-import me.mrCookieSlime.Slimefun.api.BlockStorage;
-import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
-import me.profelements.dynatech.DynaTech;
-
-import org.bukkit.Location;
-import org.bukkit.block.data.BlockData;
-import org.bukkit.block.data.Waterlogged;
-import org.bukkit.inventory.ItemStack;
-
-import io.github.thebusybiscuit.slimefun4.api.items.ItemSetting;
-import io.github.thebusybiscuit.slimefun4.api.items.settings.IntRangeSetting;
+package me.profelements.dynatech.items.electric.generators;
+
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import io.github.thebusybiscuit.slimefun4.core.attributes.EnergyNetProvider;
 import io.github.thebusybiscuit.slimefun4.libraries.paperlib.PaperLib;
+import me.mrCookieSlime.CSCoreLibPlugin.Configuration.Config;
+import me.mrCookieSlime.Slimefun.Lists.RecipeType;
+import me.mrCookieSlime.Slimefun.Objects.Category;
+import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;
+import me.mrCookieSlime.Slimefun.api.SlimefunItemStack;
+import me.mrCookieSlime.Slimefun.cscorelib2.blocks.BlockPosition;
+import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.block.Block;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.block.data.Waterlogged;
+import org.bukkit.inventory.ItemStack;
 
 import javax.annotation.Nonnull;
+import java.util.concurrent.TimeUnit;
 
 public class HydroGenerator extends SlimefunItem implements EnergyNetProvider {
-    
-    private final ItemSetting<Integer> checkingInterval = new IntRangeSetting(this, "check-for-water-interal", 0, 10, 100);
 
     private final int energy;
     private final int capacity;
 
-    public HydroGenerator(Category category, int energy, int capacity, SlimefunItemStack item, RecipeType recipeType, ItemStack[] recipe) {
+    private final LoadingCache<BlockPosition, Integer> cachedGeneration = CacheBuilder.newBuilder()
+        .refreshAfterWrite(1, TimeUnit.MINUTES)
+        .expireAfterAccess(3, TimeUnit.MINUTES)
+        .build(new CacheLoader<>() {
+            @Override
+            public Integer load(@Nonnull BlockPosition key) {
+                return fetchOutputForBlock(key);
+            }
+        });
+
+    public HydroGenerator(Category category, int energy, int capacity, SlimefunItemStack item, RecipeType recipeType,
+                          ItemStack[] recipe) {
         super(category, item, recipeType, recipe);
 
         this.energy = energy;
         this.capacity = capacity;
-        
-        addItemSetting(checkingInterval);
     }
 
     @Override
     public int getGeneratedOutput(@Nonnull Location location, @Nonnull Config config) {
-        if (DynaTech.getInstance().getTickInterval()  % checkingInterval.getValue() == 0) {
-            BlockData blockData = PaperLib.getBlockState(location.getBlock(), false).getState().getBlockData();
+        final BlockPosition pos = new BlockPosition(location);
+        Integer i = cachedGeneration.getIfPresent(pos);
+
+        if (i != null) {
+            return i;
+        } else {
+            int output = fetchOutputForBlock(pos);
+            cachedGeneration.put(pos, output);
+            return output;
+        }
+    }
+
+    private int fetchOutputForBlock(@Nonnull BlockPosition position) {
+        final Block b = position.getBlock();
+
+        if (b.getType() == Material.COBBLESTONE_WALL || b.getType() == Material.PRISMARINE_WALL) {
+            BlockData blockData = PaperLib.getBlockState(b, false).getState().getBlockData();
             if (blockData instanceof Waterlogged) {
                 Waterlogged data = (Waterlogged) blockData;
                 if (data.isWaterlogged()) {
-                    BlockStorage.addBlockInfo(location, "waterlogged", String.valueOf(true));
                     return getEnergyProduction();
-                } else {
-                    BlockStorage.addBlockInfo(location, "waterlogged", String.valueOf(false));
                 }
             }
-            return 0;
-        } else if (BlockStorage.getLocationInfo(location, "waterlogged") != null && BlockStorage.getLocationInfo(location, "waterlogged").equals(String.valueOf(true))){
-            return getEnergyProduction();
+        } else {
+            // Block has been removed, invalidate the cache
+            cachedGeneration.invalidate(position);
         }
-        return 0;        
+        return 0;
     }
 
     @Override
@@ -61,12 +82,12 @@ public class HydroGenerator extends SlimefunItem implements EnergyNetProvider {
         return false;
     }
 
-   public int getEnergyProduction() {
-    return energy;
-   }
+    public int getEnergyProduction() {
+        return energy;
+    }
 
-@Override
-public int getCapacity() {
-    return capacity;
-}
+    @Override
+    public int getCapacity() {
+        return capacity;
+    }
 }

--- a/src/main/java/me/profelements/dynatech/items/misc/DimensionalHomeDimension.java
+++ b/src/main/java/me/profelements/dynatech/items/misc/DimensionalHomeDimension.java
@@ -1,13 +1,12 @@
 package me.profelements.dynatech.items.misc;
 
-import java.util.Random;
-
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.generator.ChunkGenerator;
 
 import javax.annotation.Nonnull;
 import javax.annotation.ParametersAreNonnullByDefault;
+import java.util.Random;
 
 public class DimensionalHomeDimension extends ChunkGenerator {
 
@@ -19,22 +18,22 @@ public class DimensionalHomeDimension extends ChunkGenerator {
 
         chunkData.setRegion(0, 59, 0, 16, 60, 16, Material.BEDROCK);
         for (int y = 60; y < 180; y++) {
-            for (int x = 0; x <16; x++) {
+            for (int x = 0; x < 16; x++) {
                 chunkData.setBlock(x, y, 0, Material.BARRIER);
                 chunkData.setBlock(x, y, 16, Material.BARRIER);
             }
-            for (int z = 0; z <16; z++) {
+            for (int z = 0; z < 16; z++) {
                 chunkData.setBlock(0, y, z, Material.BARRIER);
                 chunkData.setBlock(16, y, z, Material.BARRIER);
             }
-            
+
         }
-        for(int x2 = 0; x2 < 16; x2++) {
+        for (int x2 = 0; x2 < 16; x2++) {
             for (int y2 = 0; y2 < 16; y2++) {
                 chunkData.setBlock(x2, 180, y2, Material.BARRIER);
             }
         }
         return chunkData;
-    } 
+    }
 
 }

--- a/src/main/java/me/profelements/dynatech/setup/DynaTechItemsSetup.java
+++ b/src/main/java/me/profelements/dynatech/setup/DynaTechItemsSetup.java
@@ -1,8 +1,11 @@
-package me.profelements.dynatech.setup;
-
-import io.github.mooy1.infinityexpansion.items.MobData;
-import io.github.mooy1.infinityexpansion.items.mobdata.MobDataCard;
-import io.github.mooy1.infinityexpansion.items.mobdata.MobDataTier;
+package me.profelements.dynatech.setup;
+
+import io.github.mooy1.infinityexpansion.items.MobData;
+
+import io.github.mooy1.infinityexpansion.items.mobdata.MobDataCard;
+
+import io.github.mooy1.infinityexpansion.items.mobdata.MobDataTier;
+
 import io.github.thebusybiscuit.slimefun4.implementation.SlimefunItems;
 import me.mrCookieSlime.Slimefun.Lists.RecipeType;
 import me.mrCookieSlime.Slimefun.Objects.SlimefunItem.SlimefunItem;


### PR DESCRIPTION
There have been multiple improvements in this PR:
* Massively improved hydro gens
  - Use a Guava Cache to cache the energy values. These will be refreshed every 1 min (ish).
  - Remove the BlockStorage stuff which is SLOW - BlockStorage serializes and deserializes a ton which is slow.
* Optimised Chipping Generator
  - getProgressBar was returning a NEW object everytime, fixed that
  - Avoid any expensive item checks (with != null, != air, etc)
  - Avoid multiple calls to getItemMeta - getItemMeta will do **multiple** clones, it's slow! Make sure to only ever do this once
* Optimised dragon egg gen
  - The things you did to try and optimise this just slow it down. While creating a new Block instance isn't great it's a hell of a lot quicker than a lot of BlockStorage stuff
* Removed some redundant runSync's
* Fixed general formatting issues and inconsistencies 

Hydro gen before:
![image](https://user-images.githubusercontent.com/8492901/120902198-d17b8980-c636-11eb-83d3-4b635d13aa39.png)

After:
```
[19:30:49 INFO]: Slimefun 4> Please wait a second... The results are coming in!
[19:30:49 INFO]: 
[19:30:49 INFO]: ===== Slimefun Lag Profiler =====
[19:30:49 INFO]: Total time: 0.55ms
[19:30:49 INFO]: Running every: 0.6s (12 ticks)
[19:30:49 INFO]: Performance: :::::::::::::::::::: - Good (1%)
[19:30:49 INFO]: 
[19:30:49 INFO]: 32 blocks
  ...
  WATER_MILL - 3x (0.01ms | avg: 0ms)
  WATER_TURBINE - 3x (0ms | avg: 0ms)
```

---
**Note**: I have not tested this extensively. I have only tested the hydro stuff some. Theoretically it should all be fine regardless but yeah