### PR TITLE
Fix Growth Chamber deleting when using EG trees

### DIFF
--- a/src/main/java/me/profelements/dynatech/items/electric/growthchambers/GrowthChamber.java
+++ b/src/main/java/me/profelements/dynatech/items/electric/growthchambers/GrowthChamber.java
@@ -85,7 +85,7 @@ public class GrowthChamber extends AMachine {
                     SlimefunItem sfItem = SlimefunItem.getByItem(item);
                     if (sfItem.getId().contains("_BUSH") || sfItem.getId().contains("_PLANT") || sfItem.getId().contains("_SAPLING")) {
                         if (sfItem.getId().contains("_BUSH")) {
-                            ItemStack fruit = SlimefunItem.getById(sfItem.getId().replace("_BUSH", "")).getItem();
+                            ItemStack fruit = SlimefunItem.getById(sfItem.getId().replace("_BUSH", "")).getItem().clone();
                             MachineRecipe recipe = new MachineRecipe(21, new ItemStack[] {sfItem.getItem()}, new ItemStack[] {sfItem.getItem(), fruit});
                             
                             inv.consumeItem(inputSlot);
@@ -93,7 +93,7 @@ public class GrowthChamber extends AMachine {
                             return recipe;
                         } else 
                         if (sfItem.getId().contains("_PLANT")) {
-                            ItemStack fruit = SlimefunItem.getById(sfItem.getId().replace("_PLANT", "")) != null ? SlimefunItem.getById(sfItem.getId().replace("_PLANT", "")).getItem() : SlimefunItem.getById(sfItem.getId().replace("_PLANT", "_ESSENCE")).getItem();
+                            ItemStack fruit = SlimefunItem.getById(sfItem.getId().replace("_PLANT", "")) != null ? SlimefunItem.getById(sfItem.getId().replace("_PLANT", "")).getItem().clone() : SlimefunItem.getById(sfItem.getId().replace("_PLANT", "_ESSENCE")).getItem().clone();
                             MachineRecipe recipe = new MachineRecipe(12, new ItemStack[] {sfItem.getItem()}, new ItemStack[] {sfItem.getItem(), fruit});
                             
                             inv.consumeItem(inputSlot);
@@ -101,7 +101,7 @@ public class GrowthChamber extends AMachine {
                             return recipe;
                         } else
                         if (sfItem.getId().contains("_SAPLING")) {
-                            ItemStack fruit = SlimefunItem.getById(sfItem.getId().replace("_SAPLING", "")).getItem();
+                            ItemStack fruit = SlimefunItem.getById(sfItem.getId().replace("_SAPLING", "")).getItem().clone();
                             fruit.setAmount(3);
                             MachineRecipe recipe = new MachineRecipe(30, new ItemStack[] {sfItem.getItem()}, new ItemStack[] {sfItem.getItem(), fruit});
                             


### PR DESCRIPTION
Since the items were never cloned, the growth chamber was always referring to the original item. This is fine (although frowned upon) as long as you leave the ItemStack unchanged as it is Immutable, but with EG trees the amount is set to 3 which errors as you can't change an Immutable ItemStack.
Here is an error example of the above happening: https://pastebin.com/BkncFq96
Cloning the ItemStack will circumvent the issue, I cloned all of them for coherence.