### PR TITLE
Move wither skeleton spawn location to golem center instead of player location

### DIFF
--- a/src/main/java/me/profelements/dynatech/items/misc/WitherGolem.java
+++ b/src/main/java/me/profelements/dynatech/items/misc/WitherGolem.java
@@ -23,7 +23,7 @@ public class WitherGolem extends MultiBlockMachine {
     Block pumpkinHead = b.getRelative(BlockFace.UP);
     Block bottomBlackstone = b.getRelative(BlockFace.DOWN);
   
-    p.getWorld().spawnEntity(p.getLocation(), EntityType.WITHER_SKELETON);
+    p.getWorld().spawnEntity(b.getLocation().add(0.5, -1, 0.5), EntityType.WITHER_SKELETON);
 
     pumpkinHead.setType(Material.AIR);
     b.setType(Material.AIR);


### PR DESCRIPTION
Basic location fix to move the wither golem's spawn location to the center of the multiblock structure
Currently drops the golem straight onto the player

-1 y offset to spawn on ground
+0.5x and +0.5z to center in block