### PR TITLE
Default auto-update to false

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,3 +1,3 @@
 options:
-  auto-update: true
+  auto-update: false
   disable-dimensionalhome-world: false


### PR DESCRIPTION
This is a change that may well be rejected but given the recent breaking changes as well as the clear indication that this will be the working method moving forward, I think it's important to lean towards not defaulting to auto-update: true.

This will allow new servers taking DynaTech on to sit comfortably on their current version without having to worry about it. 
This may well benefit from another PR to point out potential future updates to server owners/admins? 